### PR TITLE
Add NodeOutput::end() alias

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -51,6 +51,11 @@ impl NodeOutput {
         Self::Finish
     }
 
+    /// Alias for `finish()` - ends graph execution
+    pub fn end() -> Self {
+        Self::Finish
+    }
+
     /// Create a route output to a specific node
     pub fn route(target: impl Into<String>) -> Self {
         Self::Route(target.into())


### PR DESCRIPTION
## Summary
- Adds `NodeOutput::end()` as an alias for `NodeOutput::finish()`
- More intuitive API for ending graph execution

## Test plan
- [x] All 41 tests pass
- [x] Tested with crates.io install

🤖 Generated with [Claude Code](https://claude.com/claude-code)