### PR TITLE
Deprecate dual implementations, add integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - Unreleased
+
+### Deprecated
+
+- Generic `Node<S: State>` trait in `node` module — use `NodeExecutor` from `graph` module instead
+- Generic `Edge<S>` enum in `edge` module — use `EdgeType` and `GraphEdge` from `graph` module instead
+- `Router<S>` trait in `edge` module — use conditional edges in `GraphBuilder` instead
+- `FnNode<S>`, `WrappedNode<S>`, `BoxedNode<S>` — use `FunctionNode` or implement `NodeExecutor` directly
+
+### Added
+
+- Integration tests for complex graph patterns (`tests/graph_patterns.rs`)
+  - Multi-branch conditional routing
+  - Cycle with exit condition
+  - Recursion limit enforcement
+  - Error propagation through runner
+  - Deep linear graph (50 nodes)
+  - Concurrent state mutation
+  - Conditional edge routing
+  - Node finish semantics
+  - Message manipulation
+- ADR-001: Architectural decision to consolidate on single implementation
+- Migration guide for deprecated APIs (`docs/MIGRATION-0.2.md`)
+- This changelog
+
+### Fixed
+
+- `FnNode<S>` Sync bound on `Fut` generic parameter (in deprecated `node` module)
+
+### Notes
+
+Deprecated APIs will be removed in v0.3.0 (planned 2-3 months after v0.2.0 release).
+The `runtime.rs` file is dead code (not in module tree) and will also be deleted in v0.3.0.
+See `docs/MIGRATION-0.2.md` for migration guide and `docs/ADR-001-single-implementation.md` for rationale.
+
+## [0.1.1] - 2024
+
+### Added
+
+- Initial release with `NodeExecutor`, `GraphBuilder`, `GraphRunner`
+- Built-in nodes: Echo, Delay, Conditional, Function, LLM, Tool
+- `AgentState` with `SharedState` (`Arc<RwLock>`) thread-safe state management
+- petgraph-based graph structure
+- Mermaid diagram generation
+- Git integration module

--- a/docs/ADR-001-single-implementation.md
+++ b/docs/ADR-001-single-implementation.md
@@ -1,0 +1,44 @@
+# ADR 001: Consolidate on NodeExecutor + AgentState Implementation
+
+## Status
+
+Accepted
+
+## Context
+
+oxidizedgraph evolved with two parallel implementations:
+
+1. **Generic traits** (`node.rs`, `edge.rs`): `Node<S: State>`, `Edge<S>`, `Router<S>` with parameterized state. An incomplete exploratory approach — the corresponding `Runtime<S>` in `runtime.rs` references a generic `CompiledGraph<S>` that no longer exists.
+
+2. **Concrete types** (`graph.rs`, `runner.rs`): `NodeExecutor`, `EdgeType`, `GraphBuilder`, `GraphRunner` with `AgentState` and `SharedState` (`Arc<RwLock<AgentState>>`). This is the production implementation used by all examples, built-in nodes, and the execution runtime.
+
+The generic files (`node.rs`, `edge.rs`, `runtime.rs`) were never wired into `lib.rs` and sat as orphaned dead code. All downstream consumers use the concrete implementation.
+
+## Decision
+
+1. **v0.2.0**: Re-add `node` and `edge` modules to `lib.rs` with `#[deprecated]` attributes. Leave `runtime.rs` out of the module tree (it won't compile against current `CompiledGraph`). Document the planned removal.
+
+2. **v0.3.0**: Delete `node.rs`, `edge.rs`, `runtime.rs`. Remove module declarations from `lib.rs`.
+
+### Rationale
+
+- Concrete types are simpler and more ergonomic for the LangGraph use case.
+- `AgentState` with `SharedState` (`Arc<RwLock>`) provides the right level of abstraction.
+- Generic approach adds complexity without clear benefits — it was never completed.
+- Enables cleaner integration with the stevedores-org ecosystem (llama.rs, oxidizedMLX, oxidizedRAG).
+
+## Consequences
+
+- **Positive**: Simpler codebase, clearer API surface, easier ecosystem integration.
+- **Negative**: Breaking change for anyone using generic traits (extremely unlikely since they were never exported).
+- **Mitigation**: Deprecation period with compiler warnings, migration guide, semver compliance.
+
+## Integration Benefits
+
+Concrete `AgentState` + `NodeExecutor` enables direct integration with:
+
+- **llama.rs**: LLM inference backend for `LLMNode`
+- **oxidizedMLX**: Apple Silicon acceleration for model execution
+- **oxidizedRAG**: Knowledge retrieval for agent context
+- **local-ci**: Test workflow graphs as part of CI
+- **aivcs**: Version control for graph definitions and state

--- a/docs/MIGRATION-0.2.md
+++ b/docs/MIGRATION-0.2.md
@@ -1,0 +1,63 @@
+# Migration Guide: 0.1.x → 0.2.0
+
+## Deprecated APIs
+
+The generic `Node<S>`, `Edge<S>`, and `Router<S>` traits in the `node` and `edge` modules are deprecated. These were never part of the default prelude and were previously not even compiled into the crate. If you were somehow using them directly, migrate to the primary API.
+
+### Before (deprecated)
+
+```rust
+use oxidizedgraph::node::Node;
+use oxidizedgraph::edge::Edge;
+
+struct MyNode;
+
+#[async_trait]
+impl<S: State> Node<S> for MyNode {
+    fn id(&self) -> &str { "my_node" }
+    async fn run(&self, state: S) -> Result<NodeResult<S>, NodeError> {
+        Ok(NodeResult::Continue(state))
+    }
+}
+```
+
+### After (recommended)
+
+```rust
+use oxidizedgraph::prelude::*;
+
+struct MyNode;
+
+#[async_trait]
+impl NodeExecutor for MyNode {
+    fn id(&self) -> &str { "my_node" }
+
+    async fn execute(&self, state: SharedState) -> Result<NodeOutput, NodeError> {
+        let mut guard = state.write().map_err(|e| NodeError::execution_failed(e.to_string()))?;
+        // Modify state via Arc<RwLock<AgentState>>
+        Ok(NodeOutput::cont())
+    }
+}
+```
+
+### Key Differences
+
+| Aspect | Generic (`Node<S>`) | Concrete (`NodeExecutor`) |
+|--------|---------------------|---------------------------|
+| State type | Generic `S: State` | Fixed `SharedState` (`Arc<RwLock<AgentState>>`) |
+| Method | `run(&self, state: S)` | `execute(&self, state: SharedState)` |
+| Return | `NodeResult<S>` | `NodeOutput` |
+| Thread safety | Caller manages | Built-in via `Arc<RwLock>` |
+| Builder | None | `GraphBuilder` fluent API |
+| Runner | `Runtime<S>` (incomplete) | `GraphRunner` (production-ready) |
+
+### Dead Code: `runtime.rs`
+
+The `runtime.rs` file contains an incomplete `Runtime<S>` that references a generic `CompiledGraph<S>` which no longer exists. This file is not part of the module tree and is not compiled. It will be deleted in v0.3.0.
+
+Note: `runner.rs` exports `pub type Runtime = GraphRunner;` as a convenience alias — this is the correct runtime to use.
+
+## Timeline
+
+- **v0.2.0**: Deprecation warnings added to `node` and `edge` modules
+- **v0.3.0** (2-3 months later): Deprecated modules and `runtime.rs` removed

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1,8 +1,9 @@
-//! Edge definitions for oxidizedgraph
+//! Legacy edge definitions for oxidizedgraph
 //!
-//! Edges define the transitions between nodes in a graph.
-//! They can be direct (always go to a specific node) or
-//! conditional (choose based on state).
+//! **Deprecated:** This module contains an unused generic implementation.
+//! Use [`EdgeType`](crate::graph::EdgeType) and [`GraphEdge`](crate::graph::GraphEdge) from the `graph` module instead.
+//!
+//! This module will be removed in v0.3.0.
 
 use crate::state::State;
 use std::sync::Arc;
@@ -36,29 +37,11 @@ impl EdgeTarget {
     }
 }
 
+#[deprecated(
+    since = "0.2.0",
+    note = "Use conditional edges in `GraphBuilder` instead. Will be removed in 0.3.0."
+)]
 /// Conditional routing trait
-///
-/// Implement this trait to create custom routing logic based on state.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// struct ShouldContinue;
-///
-/// impl Router<MyState> for ShouldContinue {
-///     fn route(&self, state: &MyState) -> EdgeTarget {
-///         if state.is_complete {
-///             EdgeTarget::End
-///         } else {
-///             EdgeTarget::node("process")
-///         }
-///     }
-///
-///     fn possible_targets(&self) -> Vec<EdgeTarget> {
-///         vec![EdgeTarget::node("process"), EdgeTarget::End]
-///     }
-/// }
-/// ```
 pub trait Router<S: State>: Send + Sync {
     /// Determine the next edge target based on current state
     fn route(&self, state: &S) -> EdgeTarget;
@@ -116,6 +99,10 @@ where
     }
 }
 
+#[deprecated(
+    since = "0.2.0",
+    note = "Use `EdgeType` and `GraphEdge` from the `graph` module instead. Will be removed in 0.3.0."
+)]
 /// Edge definition in the graph
 pub enum Edge<S: State> {
     /// Always go to target

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,22 @@ pub mod orchestration;
 pub mod runner;
 pub mod state;
 
+// Deprecated modules — will be removed in v0.3.0
+// These contain an unused generic implementation that predates the
+// current NodeExecutor + AgentState architecture. See docs/ADR-001.
+#[deprecated(
+    since = "0.2.0",
+    note = "Use types from the `graph` module instead. Will be removed in 0.3.0."
+)]
+#[allow(deprecated)]
+pub mod edge;
+#[deprecated(
+    since = "0.2.0",
+    note = "Use `NodeExecutor` from the `graph` module instead. Will be removed in 0.3.0."
+)]
+#[allow(deprecated)]
+pub mod node;
+
 /// Convenient re-exports for common usage
 pub mod prelude;
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,9 +1,9 @@
-//! Node definitions for oxidizedgraph
+//! Legacy node definitions for oxidizedgraph
 //!
-//! Nodes are the building blocks of your workflow. Each node:
-//! - Receives the current state
-//! - Performs some action (LLM call, tool execution, etc.)
-//! - Returns an updated state with routing decision
+//! **Deprecated:** This module contains an unused generic implementation.
+//! Use [`NodeExecutor`](crate::graph::NodeExecutor) from the `graph` module instead.
+//!
+//! This module will be removed in v0.3.0.
 
 use crate::error::NodeError;
 use crate::state::State;
@@ -12,6 +12,10 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
+#[deprecated(
+    since = "0.2.0",
+    note = "Use `NodeOutput` from the `graph` module instead. Will be removed in 0.3.0."
+)]
 /// Result of node execution
 #[derive(Clone, Debug)]
 pub enum NodeResult<S: State> {
@@ -149,6 +153,10 @@ pub enum RetryOn {
     None,
 }
 
+#[deprecated(
+    since = "0.2.0",
+    note = "Use `NodeExecutor` from the `graph` module instead. Will be removed in 0.3.0."
+)]
 /// A node in the graph workflow.
 ///
 /// Nodes are the fundamental execution units. Each node:
@@ -180,22 +188,21 @@ pub trait Node<S: State>: Send + Sync {
     }
 }
 
+#[deprecated(
+    since = "0.2.0",
+    note = "Use `BoxedNodeExecutor` from the `graph` module instead. Will be removed in 0.3.0."
+)]
 /// A boxed node for type erasure
 pub type BoxedNode<S> = Box<dyn Node<S>>;
 
+#[deprecated(
+    since = "0.2.0",
+    note = "Use `FunctionNode` from the `nodes` module instead. Will be removed in 0.3.0."
+)]
 /// A node implemented as a closure.
 ///
 /// This provides a more ergonomic way to define simple nodes
 /// without creating a new struct.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// let node = FnNode::new("increment", |mut state: MyState| async move {
-///     state.counter += 1;
-///     Ok(NodeResult::Continue(state))
-/// });
-/// ```
 pub struct FnNode<S, F, Fut>
 where
     S: State,
@@ -252,7 +259,7 @@ impl<S, F, Fut> Node<S> for FnNode<S, F, Fut>
 where
     S: State,
     F: Fn(S) -> Fut + Send + Sync,
-    Fut: Future<Output = Result<NodeResult<S>, NodeError>> + Send,
+    Fut: Future<Output = Result<NodeResult<S>, NodeError>> + Send + Sync,
 {
     fn id(&self) -> &str {
         &self.id
@@ -275,6 +282,10 @@ where
     }
 }
 
+#[deprecated(
+    since = "0.2.0",
+    note = "This type is unused and will be removed in 0.3.0."
+)]
 /// A node that wraps another node with middleware-like behavior.
 pub struct WrappedNode<S: State, Inner: Node<S>> {
     inner: Inner,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,7 +1,10 @@
-//! Runtime executor for oxidizedgraph
+//! Legacy runtime executor for oxidizedgraph
 //!
-//! The `Runtime` is responsible for executing compiled graphs,
-//! managing state transitions, and handling streaming events.
+//! **DEAD CODE:** This file is NOT part of the module tree and is never compiled.
+//! It references a generic `CompiledGraph<S>` that no longer exists.
+//! Use [`GraphRunner`](crate::runner::GraphRunner) from the `runner` module instead.
+//!
+//! This file will be deleted in v0.3.0.
 
 use crate::edge::EdgeTarget;
 use crate::error::{NodeError, RuntimeError};

--- a/tests/graph_patterns.rs
+++ b/tests/graph_patterns.rs
@@ -1,0 +1,424 @@
+//! Integration tests for complex graph patterns
+//!
+//! Tests multi-branch routing, cycles, error handling, deep chains,
+//! and concurrent state access.
+
+use async_trait::async_trait;
+use oxidizedgraph::prelude::*;
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/// Node that appends its id to a "visited" context key.
+struct TrackingNode {
+    id: String,
+}
+
+impl TrackingNode {
+    fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into() }
+    }
+}
+
+#[async_trait]
+impl NodeExecutor for TrackingNode {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn execute(&self, state: SharedState) -> Result<NodeOutput, NodeError> {
+        let mut guard = state
+            .write()
+            .map_err(|e| NodeError::execution_failed(e.to_string()))?;
+        let visited = guard.get_context::<String>("visited").unwrap_or_default();
+        guard.set_context("visited", format!("{},{}", visited, self.id));
+        Ok(NodeOutput::cont())
+    }
+}
+
+/// Node that always fails.
+struct FailingNode {
+    id: String,
+    message: String,
+}
+
+impl FailingNode {
+    fn new(id: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            message: message.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl NodeExecutor for FailingNode {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn execute(&self, _state: SharedState) -> Result<NodeOutput, NodeError> {
+        Err(NodeError::execution_failed(&self.message))
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn multi_branch_conditional_routing() {
+    // Graph: start → router → (path_a | path_b | path_c) → END
+    // The router reads "route" from context and dispatches accordingly.
+
+    struct RouterNode;
+
+    #[async_trait]
+    impl NodeExecutor for RouterNode {
+        fn id(&self) -> &str {
+            "router"
+        }
+
+        async fn execute(&self, state: SharedState) -> Result<NodeOutput, NodeError> {
+            let guard = state
+                .read()
+                .map_err(|e| NodeError::execution_failed(e.to_string()))?;
+            let route: String = guard.get_context("route").unwrap_or_default();
+            Ok(NodeOutput::route(route))
+        }
+    }
+
+    // Build separate graphs for each branch since CompiledGraph isn't Clone.
+    for (route, expected) in [("path_a", ",path_a"), ("path_b", ",path_b"), ("path_c", ",path_c")] {
+        let graph = GraphBuilder::new()
+            .add_node(RouterNode)
+            .add_node(TrackingNode::new("path_a"))
+            .add_node(TrackingNode::new("path_b"))
+            .add_node(TrackingNode::new("path_c"))
+            .set_entry_point("router")
+            .add_edge_to_end("path_a")
+            .add_edge_to_end("path_b")
+            .add_edge_to_end("path_c")
+            .compile()
+            .unwrap();
+
+        let runner = GraphRunner::with_defaults(graph);
+        let mut state = AgentState::new();
+        state.set_context("route", route.to_string());
+
+        let result = runner.invoke(state).await.unwrap();
+        let visited: String = result.get_context("visited").unwrap_or_default();
+        assert_eq!(visited, expected, "route={route}");
+    }
+}
+
+#[tokio::test]
+async fn cycle_with_exit_condition() {
+    // A node that loops back to itself until counter reaches a threshold,
+    // then finishes.
+
+    struct LoopNode {
+        max: i32,
+    }
+
+    #[async_trait]
+    impl NodeExecutor for LoopNode {
+        fn id(&self) -> &str {
+            "loop"
+        }
+
+        async fn execute(&self, state: SharedState) -> Result<NodeOutput, NodeError> {
+            let mut guard = state
+                .write()
+                .map_err(|e| NodeError::execution_failed(e.to_string()))?;
+            let count = guard.get_context::<i32>("count").unwrap_or(0);
+            guard.set_context("count", count + 1);
+
+            if count + 1 >= self.max {
+                Ok(NodeOutput::finish())
+            } else {
+                Ok(NodeOutput::continue_to("loop"))
+            }
+        }
+    }
+
+    let graph = GraphBuilder::new()
+        .add_node(LoopNode { max: 5 })
+        .set_entry_point("loop")
+        .compile()
+        .unwrap();
+
+    let runner = GraphRunner::with_defaults(graph);
+    let result = runner.invoke(AgentState::new()).await.unwrap();
+
+    assert_eq!(result.get_context::<i32>("count"), Some(5));
+}
+
+#[tokio::test]
+async fn cycle_hits_recursion_limit() {
+    // Infinite loop should be stopped by the recursion limit.
+
+    struct InfiniteNode;
+
+    #[async_trait]
+    impl NodeExecutor for InfiniteNode {
+        fn id(&self) -> &str {
+            "infinite"
+        }
+
+        async fn execute(&self, _state: SharedState) -> Result<NodeOutput, NodeError> {
+            Ok(NodeOutput::continue_to("infinite"))
+        }
+    }
+
+    let graph = GraphBuilder::new()
+        .add_node(InfiniteNode)
+        .set_entry_point("infinite")
+        .compile()
+        .unwrap();
+
+    let runner = GraphRunner::new(graph, RunnerConfig::new().max_iterations(10));
+    let result = runner.invoke(AgentState::new()).await;
+
+    assert!(
+        matches!(result, Err(RuntimeError::RecursionLimit(10))),
+        "expected RecursionLimit(10), got {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn error_propagation() {
+    // A failing node should propagate its error through the runner.
+
+    let graph = GraphBuilder::new()
+        .add_node(TrackingNode::new("ok_node"))
+        .add_node(FailingNode::new("bad_node", "something broke"))
+        .set_entry_point("ok_node")
+        .add_edge("ok_node", "bad_node")
+        .compile()
+        .unwrap();
+
+    let runner = GraphRunner::with_defaults(graph);
+    let result = runner.invoke(AgentState::new()).await;
+
+    match result {
+        Err(RuntimeError::NodeFailed { node_id, error }) => {
+            assert_eq!(node_id, "bad_node");
+            assert!(error.to_string().contains("something broke"));
+        }
+        other => panic!("expected NodeFailed, got {:?}", other),
+    }
+
+    // Verify the first node did execute before the failure
+    // (state is consumed by runner, but the error proves "ok_node" ran
+    // since we reached "bad_node" via the edge from "ok_node")
+}
+
+#[tokio::test]
+async fn deep_linear_graph() {
+    // Chain of 50 nodes to verify no stack overflow and correct ordering.
+
+    const DEPTH: usize = 50;
+
+    let mut builder = GraphBuilder::new();
+
+    for i in 0..DEPTH {
+        builder = builder.add_node(TrackingNode::new(format!("n{i}")));
+    }
+
+    builder = builder.set_entry_point("n0");
+
+    for i in 0..(DEPTH - 1) {
+        builder = builder.add_edge(format!("n{i}"), format!("n{}", i + 1));
+    }
+
+    builder = builder.add_edge_to_end(format!("n{}", DEPTH - 1));
+
+    let graph = builder.compile().unwrap();
+    let runner = GraphRunner::with_defaults(graph);
+    let result = runner.invoke(AgentState::new()).await.unwrap();
+
+    let visited: String = result.get_context("visited").unwrap_or_default();
+    let parts: Vec<&str> = visited.split(',').filter(|s| !s.is_empty()).collect();
+    assert_eq!(parts.len(), DEPTH);
+    assert_eq!(parts[0], "n0");
+    assert_eq!(parts[DEPTH - 1], format!("n{}", DEPTH - 1));
+}
+
+#[tokio::test]
+async fn concurrent_state_mutation() {
+    // Multiple nodes sequentially mutating shared state.
+    // Verifies Arc<RwLock> prevents races and final state is consistent.
+
+    struct IncrementNode {
+        id: String,
+        key: String,
+        amount: i32,
+    }
+
+    #[async_trait]
+    impl NodeExecutor for IncrementNode {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        async fn execute(&self, state: SharedState) -> Result<NodeOutput, NodeError> {
+            let mut guard = state
+                .write()
+                .map_err(|e| NodeError::execution_failed(e.to_string()))?;
+            let current = guard.get_context::<i32>(&self.key).unwrap_or(0);
+            guard.set_context(&self.key, current + self.amount);
+            Ok(NodeOutput::cont())
+        }
+    }
+
+    let graph = GraphBuilder::new()
+        .add_node(IncrementNode {
+            id: "add10".to_string(),
+            key: "total".to_string(),
+            amount: 10,
+        })
+        .add_node(IncrementNode {
+            id: "add20".to_string(),
+            key: "total".to_string(),
+            amount: 20,
+        })
+        .add_node(IncrementNode {
+            id: "add5".to_string(),
+            key: "total".to_string(),
+            amount: 5,
+        })
+        .set_entry_point("add10")
+        .add_edge("add10", "add20")
+        .add_edge("add20", "add5")
+        .add_edge_to_end("add5")
+        .compile()
+        .unwrap();
+
+    let runner = GraphRunner::with_defaults(graph);
+    let result = runner.invoke(AgentState::new()).await.unwrap();
+
+    assert_eq!(result.get_context::<i32>("total"), Some(35));
+}
+
+#[tokio::test]
+async fn conditional_edge_routing() {
+    // Test GraphBuilder's add_conditional_edge with a router function.
+
+    let graph = GraphBuilder::new()
+        .add_node(TrackingNode::new("start"))
+        .add_node(TrackingNode::new("yes_branch"))
+        .add_node(TrackingNode::new("no_branch"))
+        .set_entry_point("start")
+        .add_conditional_edge("start", |state: &AgentState| {
+            if state.is_complete {
+                "__end__".to_string()
+            } else {
+                "yes_branch".to_string()
+            }
+        })
+        .add_edge_to_end("yes_branch")
+        .add_edge_to_end("no_branch")
+        .compile()
+        .unwrap();
+
+    let runner = GraphRunner::with_defaults(graph);
+    let result = runner.invoke(AgentState::new()).await.unwrap();
+
+    let visited: String = result.get_context("visited").unwrap_or_default();
+    assert!(visited.contains("start"), "start should have run");
+    assert!(visited.contains("yes_branch"), "should route to yes_branch when not complete");
+}
+
+#[tokio::test]
+async fn node_output_finish_stops_immediately() {
+    // A node returning Finish should stop execution even if edges exist.
+
+    struct FinishNode;
+
+    #[async_trait]
+    impl NodeExecutor for FinishNode {
+        fn id(&self) -> &str {
+            "finisher"
+        }
+
+        async fn execute(&self, state: SharedState) -> Result<NodeOutput, NodeError> {
+            let mut guard = state
+                .write()
+                .map_err(|e| NodeError::execution_failed(e.to_string()))?;
+            guard.set_context("finished", true);
+            Ok(NodeOutput::finish())
+        }
+    }
+
+    let graph = GraphBuilder::new()
+        .add_node(FinishNode)
+        .add_node(TrackingNode::new("unreachable"))
+        .set_entry_point("finisher")
+        .add_edge("finisher", "unreachable")
+        .add_edge_to_end("unreachable")
+        .compile()
+        .unwrap();
+
+    let runner = GraphRunner::with_defaults(graph);
+    let result = runner.invoke(AgentState::new()).await.unwrap();
+
+    assert_eq!(result.get_context::<bool>("finished"), Some(true));
+    // "unreachable" should never have run
+    let visited: Option<String> = result.get_context("visited");
+    assert!(visited.is_none(), "unreachable node should not have executed");
+}
+
+#[tokio::test]
+async fn graph_with_messages() {
+    // Test that nodes can manipulate the messages list in AgentState.
+
+    struct AppendMessageNode {
+        id: String,
+        content: String,
+        role: MessageRole,
+    }
+
+    #[async_trait]
+    impl NodeExecutor for AppendMessageNode {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        async fn execute(&self, state: SharedState) -> Result<NodeOutput, NodeError> {
+            let mut guard = state
+                .write()
+                .map_err(|e| NodeError::execution_failed(e.to_string()))?;
+            match self.role {
+                MessageRole::User => guard.add_user_message(&self.content),
+                MessageRole::Assistant => guard.add_assistant_message(&self.content),
+                _ => {}
+            }
+            Ok(NodeOutput::cont())
+        }
+    }
+
+    let graph = GraphBuilder::new()
+        .add_node(AppendMessageNode {
+            id: "user_msg".to_string(),
+            content: "Hello".to_string(),
+            role: MessageRole::User,
+        })
+        .add_node(AppendMessageNode {
+            id: "assistant_msg".to_string(),
+            content: "Hi there!".to_string(),
+            role: MessageRole::Assistant,
+        })
+        .set_entry_point("user_msg")
+        .add_edge("user_msg", "assistant_msg")
+        .add_edge_to_end("assistant_msg")
+        .compile()
+        .unwrap();
+
+    let runner = GraphRunner::with_defaults(graph);
+    let result = runner.invoke(AgentState::new()).await.unwrap();
+
+    assert_eq!(result.messages.len(), 2);
+    assert_eq!(result.messages[0].role, MessageRole::User);
+    assert_eq!(result.messages[0].content, "Hello");
+    assert_eq!(result.messages[1].role, MessageRole::Assistant);
+    assert_eq!(result.messages[1].content, "Hi there!");
+}


### PR DESCRIPTION
## Summary

- Deprecate orphaned generic `Node<S>`, `Edge<S>`, `Router<S>` traits (unused, will be removed in v0.3.0)
- Add 9 integration tests for complex graph patterns (multi-branch routing, cycles, error propagation, 50-node deep chains, concurrent state, conditional edges, finish semantics, messages)
- Document architectural decision in ADR-001 and migration guide
- Add CHANGELOG.md

## Context

The codebase had dual implementations creating technical debt:
- **Active**: `NodeExecutor` + `AgentState` + `GraphRunner` (used by all examples and built-in nodes)
- **Orphaned**: Generic `Node<S>`, `Edge<S>`, `Runtime<S>` (never wired into `lib.rs`, `runtime.rs` won't even compile against current `CompiledGraph`)

This PR re-adds `node` and `edge` modules with `#[deprecated]` attributes, marks `runtime.rs` as dead code, and adds comprehensive test coverage for the active implementation. See [ADR-001](docs/ADR-001-single-implementation.md) for rationale.

Related: #2 (Epic 1 confirmed complete)

## Test plan

- [x] `cargo test` — 56 tests pass (47 unit + 9 new integration)
- [x] `cargo clippy` — warnings only in deprecated code
- [x] Integration tests cover: multi-branch conditional routing, cycle exit conditions, recursion limits, error propagation, 50-node deep linear graph, concurrent state mutation, conditional edge routing, finish semantics, message manipulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)