### PR TITLE
docs: add start-contributing map

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,57 @@
+# CODEX.md
+
+Operating notes for AI/code agents working in this repository.
+
+## Scope
+
+- Applies to the full repository.
+- Prefer minimal, focused changes per PR.
+
+## Branch and PR
+
+- Base branch: `develop`.
+- Create feature branches from `develop`.
+- Keep PRs scoped to one change theme.
+
+## Before Editing
+
+- Read: `README.md`, `CONTRIBUTING.md`.
+- For behavior changes, identify the owning module first:
+  - Graph/runtime: `src/graph.rs`, `src/runner.rs`
+  - Nodes: `src/nodes/*.rs`
+  - Checkpointing: `src/checkpoint/*.rs`
+  - Events/streaming: `src/events/*.rs`
+  - Orchestration: `src/orchestration/*.rs`
+  - Server API: `src/bin/server.rs`
+
+## Coding Standards
+
+- Rust 2021 idioms, clear error paths, no silent fallbacks for core flows.
+- Preserve existing API behavior unless intentionally changing it.
+- Avoid unrelated refactors.
+
+## Testing and Validation
+
+- Always run:
+
+```bash
+cargo test
+```
+
+- For broader verification when feasible:
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features
+```
+
+## PR Checklist
+
+- Describe the problem and approach.
+- Include test evidence.
+- Call out behavioral or compatibility changes explicitly.
+- Reference impacted files/modules.
+
+## Notes
+
+- If local environment auth/tooling differs from CI, prefer deterministic checks (`cargo test`) and document any gaps.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to oxidizedgraph
+
+This guide is a fast map for contributors who want to ship meaningful changes quickly.
+
+## Local Setup
+
+```bash
+git clone https://github.com/stevedores-org/oxidizedgraph.git
+cd oxidizedgraph
+cargo test
+```
+
+Optional checks:
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features
+```
+
+## Start Contributing Map
+
+### 1) Add or change graph semantics
+- Primary files: `src/graph.rs`, `src/runner.rs`
+- Typical tasks:
+  - new edge behavior
+  - transition resolution changes
+  - execution loop safety/invariants
+- Add/update tests in the corresponding `#[cfg(test)]` sections.
+
+### 2) Add a built-in node type
+- Primary files: `src/nodes/mod.rs`, `src/nodes/*.rs`
+- Typical tasks:
+  - new `NodeExecutor` implementation
+  - routing/output behavior via `NodeOutput`
+  - state mutation patterns
+- Add tests in the node module and export from `src/nodes/mod.rs`.
+
+### 3) Improve checkpointing and resume
+- Primary files: `src/checkpoint/mod.rs`, `src/checkpoint/memory.rs`, `src/checkpoint/runner.rs`
+- Typical tasks:
+  - checkpoint model/schema changes
+  - backend behavior
+  - resume semantics and history management
+- Validate with checkpoint runner tests and resume scenarios.
+
+### 4) Improve streaming/events/observability
+- Primary files: `src/events/types.rs`, `src/events/bus.rs`, `src/events/runner.rs`, `src/events/handler.rs`
+- Typical tasks:
+  - event schema additions
+  - event delivery behavior
+  - metrics/logging hooks
+- Ensure event compatibility and update tests for handlers and bus behavior.
+
+### 5) Extend orchestration (subgraphs/parallel)
+- Primary files: `src/orchestration/subgraph_node.rs`, `src/orchestration/parallel.rs`, `src/orchestration/spawner.rs`
+- Typical tasks:
+  - join strategy behavior
+  - result merging rules
+  - dynamic spawning lifecycle
+- Add deterministic tests for ordering and failure cases.
+
+### 6) Improve API server behavior
+- Primary file: `src/bin/server.rs`
+- Typical tasks:
+  - session lifecycle
+  - execute/checkpoint/restore endpoints
+  - API error handling and contracts
+- Add endpoint tests as server behavior becomes productionized.
+
+### 7) Work on docs/examples
+- Primary files: `README.md`, `examples/*.rs`
+- Keep examples runnable and aligned with current API.
+
+## Contribution Workflow
+
+1. Create a branch from `develop`.
+2. Make focused changes (one topic per PR).
+3. Add/update tests for behavior changes.
+4. Run `cargo test` locally.
+5. Open PR to `develop` with:
+   - problem statement
+   - design/approach
+   - test evidence
+   - follow-ups (if any)
+
+## PR Review Expectations
+
+- Behavior and correctness first.
+- Backward-compatibility impact called out.
+- Clear error semantics (no silent fallbacks for core paths).
+- Tests cover new behavior and key failure modes.

--- a/README.md
+++ b/README.md
@@ -180,4 +180,4 @@ Apache-2.0 License - see LICENSE file.
 
 ## Contributing
 
-Contributions welcome! Please open an issue or PR.
+See `CONTRIBUTING.md` for a practical start-contributing map and workflow.


### PR DESCRIPTION
## Summary
- add `CONTRIBUTING.md` with a practical start-contributing map
- map common contribution goals to concrete files/modules
- document recommended workflow, testing expectations, and PR review criteria
- link `README.md` Contributing section to `CONTRIBUTING.md`

## Why
Contributors currently have no quick path from "I want to help" to "which files should I edit first". This adds an opinionated, task-oriented map for faster onboarding and better-scoped PRs.

## Validation
- `cargo test` (all passing)
