### PR TITLE
fix: overlay namespace for NP/PDB + ECR publish on merge

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -92,7 +92,8 @@ jobs:
   publish-ecr:
     name: publish linux/amd64 image to ECR
     needs: nix
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID != ''
+    # Secrets cannot be referenced in job-level if; use repo variable ECR_PUBLISH=true.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.ECR_PUBLISH == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,6 +17,11 @@ on:
 permissions:
   contents: read
 
+env:
+  AWS_REGION: us-east-2
+  ECR_REGISTRY: 148080843892.dkr.ecr.us-east-2.amazonaws.com
+  ECR_REPOSITORY: stevedores-org/oxidizedgraph/server
+
 jobs:
   kustomize:
     name: kustomize build + kubeconform
@@ -42,6 +47,27 @@ jobs:
       - name: kustomize build (gke-autopilot overlay)
         run: kustomize build deploy/overlays/gke-autopilot > /tmp/overlay.yaml
 
+      - name: Assert NetworkPolicy and PDB use oxidizedgraph namespace
+        run: |
+          python3 <<'PY'
+          import re, sys
+          text = open("/tmp/overlay.yaml").read()
+          for kind in ("NetworkPolicy", "PodDisruptionBudget"):
+              found = False
+              for m in re.finditer(
+                  rf"kind: {kind}\nmetadata:\n(?:  [^\n]+\n)*?  namespace: (\S+)",
+                  text,
+              ):
+                  found = True
+                  if m.group(1) != "oxidizedgraph":
+                      print(f"{kind} has namespace {m.group(1)!r}, want oxidizedgraph")
+                      sys.exit(1)
+              if not found:
+                  print(f"no {kind} in overlay render")
+                  sys.exit(1)
+          print("ok: NetworkPolicy and PodDisruptionBudget in namespace oxidizedgraph")
+          PY
+
       - name: kubeconform — base
         run: kubeconform -strict -summary -kubernetes-version 1.29.0 /tmp/base.yaml
 
@@ -62,3 +88,54 @@ jobs:
             extra-trusted-public-keys = nix-cache.stevedores.org-1:Y2WLZtQTgxQ2QQzUnRDkDDKX08dL3NoNZ+Ohw3jv+7I=
       - name: build server-image
         run: nix build .#server-image -L --no-link
+
+  publish-ecr:
+    name: publish linux/amd64 image to ECR
+    needs: nix
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            accept-flake-config = true
+            extra-substituters = https://nix-cache.stevedores.org
+            extra-trusted-public-keys = nix-cache.stevedores.org-1:Y2WLZtQTgxQ2QQzUnRDkDDKX08dL3NoNZ+Ohw3jv+7I=
+
+      - name: Install skopeo
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq skopeo
+
+      - name: Ensure ECR repository exists
+        run: |
+          aws ecr describe-repositories --repository-names "$ECR_REPOSITORY" >/dev/null 2>&1 \
+            || aws ecr create-repository --repository-name "$ECR_REPOSITORY"
+
+      - name: Build OCI image (linux/amd64)
+        run: nix build .#server-image -o result -L
+
+      - name: Push to ECR
+        run: |
+          mkdir -p ~/.config/containers
+          printf '%s\n' '{"default":[{"type":"insecureAcceptAnything"}]}' > ~/.config/containers/policy.json
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+          IMAGE="${ECR_REGISTRY}/${ECR_REPOSITORY}"
+          TAG_SHA="${VERSION}-${GITHUB_SHA::7}"
+          aws ecr get-login-password --region "$AWS_REGION" \
+            | skopeo login "$ECR_REGISTRY" --username AWS --password-stdin
+          skopeo copy docker-archive:./result "docker://${IMAGE}:${VERSION}"
+          skopeo copy docker-archive:./result "docker://${IMAGE}:${TAG_SHA}"
+          skopeo copy docker-archive:./result "docker://${IMAGE}:latest"
+          echo "Pushed ${IMAGE}:${VERSION}, ${IMAGE}:${TAG_SHA}, ${IMAGE}:latest"

--- a/deploy/overlays/gke-autopilot/kustomization.yaml
+++ b/deploy/overlays/gke-autopilot/kustomization.yaml
@@ -1,6 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+# Required so overlay-only resources (NetworkPolicy, PDB) land in oxidizedgraph, not default.
+namespace: oxidizedgraph
+
 resources:
   - ../../base
   - networkpolicy.yaml

--- a/docs/DEPLOY_GKE.md
+++ b/docs/DEPLOY_GKE.md
@@ -48,6 +48,7 @@ For **linux/amd64** clusters (e.g. EKS), CI publishes Nix-built images on merge 
 |--------------|-------|
 | `AWS_ACCESS_KEY_ID` | IAM user/role with `ecr:*` push |
 | `AWS_SECRET_ACCESS_KEY` | matching secret |
+| Repository variable `ECR_PUBLISH` | `true` (enables `publish-ecr` job on merge to main) |
 | Workflow `ECR_REGISTRY` | `148080843892.dkr.ecr.us-east-2.amazonaws.com` |
 | Workflow `ECR_REPOSITORY` | `stevedores-org/oxidizedgraph/server` |
 

--- a/docs/DEPLOY_GKE.md
+++ b/docs/DEPLOY_GKE.md
@@ -40,6 +40,27 @@ kubectl -n oxidizedgraph get pods,svc,pdb,networkpolicy
 
 Local/minimal deploy without Autopilot hardening: `kubectl apply -k deploy/base`.
 
+## EKS smoke (ECR)
+
+For **linux/amd64** clusters (e.g. EKS), CI publishes Nix-built images on merge to `main` when repo secrets are set:
+
+| Secret / var | Value |
+|--------------|-------|
+| `AWS_ACCESS_KEY_ID` | IAM user/role with `ecr:*` push |
+| `AWS_SECRET_ACCESS_KEY` | matching secret |
+| Workflow `ECR_REGISTRY` | `148080843892.dkr.ecr.us-east-2.amazonaws.com` |
+| Workflow `ECR_REPOSITORY` | `stevedores-org/oxidizedgraph/server` |
+
+Tags pushed: `{Cargo version}`, `{version}-{git_sha}`, `latest`.
+
+```bash
+# After merge + publish-ecr job
+kubectl -n oxidizedgraph set image deployment/oxidizedgraph \
+  oxidizedgraph=148080843892.dkr.ecr.us-east-2.amazonaws.com/stevedores-org/oxidizedgraph/server:0.2.0
+```
+
+If NetworkPolicy/PDB were previously applied into `default`, delete them and re-apply the overlay.
+
 ## API
 
 | Endpoint | Method | Purpose |

--- a/justfile
+++ b/justfile
@@ -30,3 +30,12 @@ kustomize-check:
 
 deploy-gke:
     kubectl apply -k deploy/overlays/gke-autopilot
+
+# ECR image built by CI (linux/amd64). Override registry/repo via env.
+ecr-registry := env_var_or_default("ECR_REGISTRY", "148080843892.dkr.ecr.us-east-2.amazonaws.com")
+ecr-image := ecr-registry + "/stevedores-org/oxidizedgraph/server:" + image-tag
+
+deploy-eks:
+    kubectl apply -k deploy/overlays/gke-autopilot
+    kubectl -n oxidizedgraph set image deployment/oxidizedgraph oxidizedgraph={{ecr-image}}
+    kubectl -n oxidizedgraph rollout status deployment/oxidizedgraph


### PR DESCRIPTION
## Summary

Fixes K8s smoke-test findings from #44/#45:

1. **Namespace bug** — `NetworkPolicy` and `PodDisruptionBudget` were rendered into `default` because the overlay `kustomization.yaml` lacked `namespace: oxidizedgraph`. Overlay-only resources now inherit the correct namespace.
2. **CI guard** — `validate` job asserts NP/PDB namespace via rendered manifest check.
3. **ECR publish** — On push to `main`, `publish-ecr` builds `.#server-image` on `ubuntu-latest` (linux/amd64) and pushes to ECR when AWS secrets are configured.

## Changes

| File | Change |
|------|--------|
| `deploy/overlays/gke-autopilot/kustomization.yaml` | `namespace: oxidizedgraph` |
| `.github/workflows/validate.yml` | namespace assertion + `publish-ecr` job |
| `docs/DEPLOY_GKE.md` | EKS/ECR deploy notes |
| `justfile` | `deploy-eks` helper |

## Repo secrets (for ECR publish)

| Secret | Purpose |
|--------|---------|
| `AWS_ACCESS_KEY_ID` | ECR push (e.g. `eks-admin-sa`) |
| `AWS_SECRET_ACCESS_KEY` | matching |

If secrets are absent, `publish-ecr` is skipped; kustomize + nix jobs still run.

## Cluster cleanup (after merge)

Remove misplaced policies from `default` if present:

```bash
kubectl delete networkpolicy -n default default-deny-ingress allow-oxidizedgraph-ingress default-deny-egress allow-oxidizedgraph-egress --ignore-not-found
kubectl delete pdb -n default oxidizedgraph --ignore-not-found
kubectl apply -k deploy/overlays/gke-autopilot
```

## Test plan

- [ ] CI `kustomize build + kubeconform` green (namespace assertion)
- [ ] CI `nix build .#server-image` green
- [ ] After merge + secrets: `publish-ecr` pushes to `148080843892.dkr.ecr.us-east-2.amazonaws.com/stevedores-org/oxidizedgraph/server`
- [ ] `just deploy-eks` or manual set image → rollout → `/health`


Made with [Cursor](https://cursor.com)