### PR TITLE
fix(ci): ECR publish via GitHub OIDC (ESO/Flux aligned)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -92,8 +92,8 @@ jobs:
   publish-ecr:
     name: publish linux/amd64 image to ECR
     needs: nix
-    # Secrets cannot be referenced in job-level if; use repo variable ECR_PUBLISH=true.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.ECR_PUBLISH == 'true'
+    # GitHub OIDC → IAM role (no long-lived AWS keys). Set repo var AWS_OIDC_ROLE_ARN.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.AWS_OIDC_ROLE_ARN != ''
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -101,12 +101,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
+          role-session-name: oxidizedgraph-publish-ecr-${{ github.run_id }}
 
       - uses: cachix/install-nix-action@v27
         with:

--- a/deploy/overlays/gke-autopilot/serviceaccount-wi.yaml
+++ b/deploy/overlays/gke-autopilot/serviceaccount-wi.yaml
@@ -1,4 +1,4 @@
-# Env-specific: set your GCP SA before apply (overlay only — never commit a real project email to base).
+# GKE WI binding — production value from Flux/ESO in platform repo (placeholder for manual smoke only).
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/docs/DEPLOY_GKE.md
+++ b/docs/DEPLOY_GKE.md
@@ -40,24 +40,32 @@ kubectl -n oxidizedgraph get pods,svc,pdb,networkpolicy
 
 Local/minimal deploy without Autopilot hardening: `kubectl apply -k deploy/base`.
 
-## EKS smoke (ECR)
+## EKS / ECR (linux/amd64)
 
-For **linux/amd64** clusters (e.g. EKS), CI publishes Nix-built images on merge to `main` when repo secrets are set:
+Clusters are **amd64**; build images on CI (`ubuntu-latest` Nix), not on Apple Silicon.
 
-| Secret / var | Value |
-|--------------|-------|
-| `AWS_ACCESS_KEY_ID` | IAM user/role with `ecr:*` push |
-| `AWS_SECRET_ACCESS_KEY` | matching secret |
-| Repository variable `ECR_PUBLISH` | `true` (enables `publish-ecr` job on merge to main) |
-| Workflow `ECR_REGISTRY` | `148080843892.dkr.ecr.us-east-2.amazonaws.com` |
-| Workflow `ECR_REPOSITORY` | `stevedores-org/oxidizedgraph/server` |
+### CI publish (GitHub OIDC)
 
-Tags pushed: `{Cargo version}`, `{version}-{git_sha}`, `latest`.
+Long-lived `AWS_ACCESS_KEY_ID` in GitHub is **not** used. `publish-ecr` assumes an IAM role via **GitHub OIDC** (aligned with your ESO/Flux zero-secret posture).
+
+| Repo variable | Purpose |
+|---------------|---------|
+| `AWS_OIDC_ROLE_ARN` | IAM role trusted by `token.actions.githubusercontent.com` for this repo |
+
+Workflow env: `ECR_REGISTRY=148080843892.dkr.ecr.us-east-2.amazonaws.com`, `ECR_REPOSITORY=stevedores-org/oxidizedgraph/server`.
+
+Tags on merge to `main`: `{Cargo version}`, `{version}-{git_sha}`, `latest`.
+
+### Cluster (Flux + ESO)
+
+Runtime credentials (ECR pull, env, GKE WI bindings) are delivered by **External Secrets Operator** and **Flux** in your platform layer — not static secrets in this app repo.
+
+- **GKE**: WI annotation via Flux/ESO overlay (placeholder in `serviceaccount-wi.yaml` is smoke-only).
+- **EKS**: IRSA or `imagePullSecrets` from ESO after CI pushes to ECR.
 
 ```bash
-# After merge + publish-ecr job
-kubectl -n oxidizedgraph set image deployment/oxidizedgraph \
-  oxidizedgraph=148080843892.dkr.ecr.us-east-2.amazonaws.com/stevedores-org/oxidizedgraph/server:0.2.0
+kubectl apply -k deploy/overlays/gke-autopilot
+just deploy-eks
 ```
 
 If NetworkPolicy/PDB were previously applied into `default`, delete them and re-apply the overlay.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -50,6 +50,10 @@ Keep these in sync when releasing:
 3. `dockworker.toml` `[tags].default` and per-image `tag`
 4. `deploy/overlays/gke-autopilot/kustomization.yaml` `images.newTag`
 
+## CI / ECR (GitHub OIDC)
+
+Merge to `main` can push `linux/amd64` images to ECR when repo variable **`AWS_OIDC_ROLE_ARN`** is set (OIDC role — no `AWS_ACCESS_KEY_ID` in GitHub). Cluster pull credentials remain **ESO + Flux**.
+
 ## dockworker.toml tags
 
 - `[tags].default` and per-image `tag` track the release semver (`0.2.0`).


### PR DESCRIPTION
## Summary

Aligns with your **OIDC + ESO + Flux** secret model:

- **CI (`publish-ecr`)**: GitHub OIDC → `role-to-assume` via repo variable `AWS_OIDC_ROLE_ARN` — removes `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from the workflow.
- **Cluster**: Docs state runtime creds (ECR pull, GKE WI) come from **ESO + Flux** in the platform repo, not GitHub secrets or committed SA emails.

## Setup

Set repository variable (same trust chain as your existing OIDC infra):

| Variable | Example |
|----------|---------|
| `AWS_OIDC_ROLE_ARN` | `arn:aws:iam::148080843892:role/<github-oidc-ecr-role>` |

Role trust policy must allow `token.actions.githubusercontent.com` for `stevedores-org/oxidizedgraph`.

Removes `ECR_PUBLISH` gate — publishing runs on merge to `main` when `AWS_OIDC_ROLE_ARN` is set.

## Test plan

- [ ] CI kustomize + nix green on PR
- [ ] After merge: `publish-ecr` succeeds with OIDC role
- [ ] Flux/ESO continues to supply cluster pull secrets; `just deploy-eks` or Flux reconcile


Made with [Cursor](https://cursor.com)