### PR TITLE
fix(ci): SHA-pin OIDC action, explicit audience, robust version parse, loud preflight

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -89,10 +89,30 @@ jobs:
       - name: build server-image
         run: nix build .#server-image -L --no-link
 
+  publish-ecr-preflight:
+    name: publish-ecr preflight
+    # Runs unconditionally on push-to-main so a missing repo variable is a
+    # loud CI failure, not a silent skip of `publish-ecr`. The actual
+    # publish job's `if:` gate stays in place to short-circuit feature PRs.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify AWS_OIDC_ROLE_ARN is set
+        env:
+          ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+        run: |
+          if [[ -z "$ROLE_ARN" ]]; then
+            echo "::error::AWS_OIDC_ROLE_ARN repo variable is empty. publish-ecr will be silently skipped. Configure the variable to enable publishing — see docs/DEPLOY_GKE.md."
+            exit 1
+          fi
+          echo "✓ AWS_OIDC_ROLE_ARN is set; publish-ecr will run."
+
   publish-ecr:
     name: publish linux/amd64 image to ECR
-    needs: nix
-    # GitHub OIDC → IAM role (no long-lived AWS keys). Set repo var AWS_OIDC_ROLE_ARN.
+    needs: [nix, publish-ecr-preflight]
+    # Use vars (not secrets) — secrets can't be referenced in job-level `if`.
+    # The preflight job above turns a missing variable into a visible failure;
+    # this gate still short-circuits non-main pushes and PR runs.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.AWS_OIDC_ROLE_ARN != ''
     runs-on: ubuntu-latest
     permissions:
@@ -102,11 +122,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        # SHA-pinned per security policy — floating @v4 lets a compromised
+        # release of this action mint AWS credentials on our behalf. Bump
+        # via Dependabot; comment carries the human-readable version.
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: oxidizedgraph-publish-ecr-${{ github.run_id }}
+          # Explicit audience so a future trust-policy reshuffle has the
+          # matching value at hand. `sts.amazonaws.com` is the action's
+          # default; declaring it makes the contract visible.
+          audience: sts.amazonaws.com
+          role-session-name: oxidizedgraph-publish-ecr-${{ github.run_id }}-${{ github.run_attempt }}
 
       - uses: cachix/install-nix-action@v27
         with:
@@ -131,7 +158,16 @@ jobs:
         run: |
           mkdir -p ~/.config/containers
           printf '%s\n' '{"default":[{"type":"insecureAcceptAnything"}]}' > ~/.config/containers/policy.json
-          VERSION=$(grep '^version' Cargo.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+          # Parse the published-package version from cargo metadata so we're
+          # immune to: workspace.package.version moves, `# version = ...`
+          # comment lines, and dep entries that sort before the [package]
+          # block via `head -1`. `jq` ships on ubuntu-latest.
+          VERSION=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name=="oxidizedgraph") | .version')
+          if [[ -z "$VERSION" ]]; then
+            echo "::error::Failed to parse package version from cargo metadata"
+            exit 1
+          fi
           IMAGE="${ECR_REGISTRY}/${ECR_REPOSITORY}"
           TAG_SHA="${VERSION}-${GITHUB_SHA::7}"
           aws ecr get-login-password --region "$AWS_REGION" \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -92,8 +92,8 @@ jobs:
   publish-ecr:
     name: publish linux/amd64 image to ECR
     needs: nix
-    # Secrets cannot be referenced in job-level if; use repo variable ECR_PUBLISH=true.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.ECR_PUBLISH == 'true'
+    # GitHub OIDC → IAM role (no long-lived AWS keys). Set repo var AWS_OIDC_ROLE_ARN.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.AWS_OIDC_ROLE_ARN != ''
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -101,12 +101,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
+          role-session-name: oxidizedgraph-publish-ecr-${{ github.run_id }}
 
       - uses: cachix/install-nix-action@v27
         with:

--- a/deploy/overlays/gke-autopilot/serviceaccount-wi.yaml
+++ b/deploy/overlays/gke-autopilot/serviceaccount-wi.yaml
@@ -1,4 +1,4 @@
-# Env-specific: set your GCP SA before apply (overlay only — never commit a real project email to base).
+# GKE WI binding — production value from Flux/ESO in platform repo (placeholder for manual smoke only).
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/docs/DEPLOY_GKE.md
+++ b/docs/DEPLOY_GKE.md
@@ -40,24 +40,32 @@ kubectl -n oxidizedgraph get pods,svc,pdb,networkpolicy
 
 Local/minimal deploy without Autopilot hardening: `kubectl apply -k deploy/base`.
 
-## EKS smoke (ECR)
+## EKS / ECR (linux/amd64)
 
-For **linux/amd64** clusters (e.g. EKS), CI publishes Nix-built images on merge to `main` when repo secrets are set:
+Clusters are **amd64**; build images on CI (`ubuntu-latest` Nix), not on Apple Silicon.
 
-| Secret / var | Value |
-|--------------|-------|
-| `AWS_ACCESS_KEY_ID` | IAM user/role with `ecr:*` push |
-| `AWS_SECRET_ACCESS_KEY` | matching secret |
-| Repository variable `ECR_PUBLISH` | `true` (enables `publish-ecr` job on merge to main) |
-| Workflow `ECR_REGISTRY` | `148080843892.dkr.ecr.us-east-2.amazonaws.com` |
-| Workflow `ECR_REPOSITORY` | `stevedores-org/oxidizedgraph/server` |
+### CI publish (GitHub OIDC)
 
-Tags pushed: `{Cargo version}`, `{version}-{git_sha}`, `latest`.
+Long-lived `AWS_ACCESS_KEY_ID` in GitHub is **not** used. `publish-ecr` assumes an IAM role via **GitHub OIDC** (aligned with your ESO/Flux zero-secret posture).
+
+| Repo variable | Purpose |
+|---------------|---------|
+| `AWS_OIDC_ROLE_ARN` | IAM role trusted by `token.actions.githubusercontent.com` for this repo |
+
+Workflow env: `ECR_REGISTRY=148080843892.dkr.ecr.us-east-2.amazonaws.com`, `ECR_REPOSITORY=stevedores-org/oxidizedgraph/server`.
+
+Tags on merge to `main`: `{Cargo version}`, `{version}-{git_sha}`, `latest`.
+
+### Cluster (Flux + ESO)
+
+Runtime credentials (ECR pull, env, GKE WI bindings) are delivered by **External Secrets Operator** and **Flux** in your platform layer — not static secrets in this app repo.
+
+- **GKE**: WI annotation via Flux/ESO overlay (placeholder in `serviceaccount-wi.yaml` is smoke-only).
+- **EKS**: IRSA or `imagePullSecrets` from ESO after CI pushes to ECR.
 
 ```bash
-# After merge + publish-ecr job
-kubectl -n oxidizedgraph set image deployment/oxidizedgraph \
-  oxidizedgraph=148080843892.dkr.ecr.us-east-2.amazonaws.com/stevedores-org/oxidizedgraph/server:0.2.0
+kubectl apply -k deploy/overlays/gke-autopilot
+just deploy-eks
 ```
 
 If NetworkPolicy/PDB were previously applied into `default`, delete them and re-apply the overlay.

--- a/docs/DEPLOY_GKE.md
+++ b/docs/DEPLOY_GKE.md
@@ -52,6 +52,10 @@ Long-lived `AWS_ACCESS_KEY_ID` in GitHub is **not** used. `publish-ecr` assumes 
 |---------------|---------|
 | `AWS_OIDC_ROLE_ARN` | IAM role trusted by `token.actions.githubusercontent.com` for this repo |
 
+**Trust-policy contract.** The IAM role specified by `AWS_OIDC_ROLE_ARN` must trust the GitHub OIDC provider for **audience** `sts.amazonaws.com` and **subject** matching `repo:stevedores-org/oxidizedgraph:*` (or scoped to a specific ref, e.g. `repo:stevedores-org/oxidizedgraph:ref:refs/heads/main`). The workflow declares the audience explicitly so a trust-policy reshuffle has the matching value at hand.
+
+A missing `AWS_OIDC_ROLE_ARN` is a loud CI failure (the `publish-ecr-preflight` job exits non-zero on every push to `main`), not a silent skip.
+
 Workflow env: `ECR_REGISTRY=148080843892.dkr.ecr.us-east-2.amazonaws.com`, `ECR_REPOSITORY=stevedores-org/oxidizedgraph/server`.
 
 Tags on merge to `main`: `{Cargo version}`, `{version}-{git_sha}`, `latest`.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -50,6 +50,10 @@ Keep these in sync when releasing:
 3. `dockworker.toml` `[tags].default` and per-image `tag`
 4. `deploy/overlays/gke-autopilot/kustomization.yaml` `images.newTag`
 
+## CI / ECR (GitHub OIDC)
+
+Merge to `main` can push `linux/amd64` images to ECR when repo variable **`AWS_OIDC_ROLE_ARN`** is set (OIDC role — no `AWS_ACCESS_KEY_ID` in GitHub). Cluster pull credentials remain **ESO + Flux**.
+
 ## dockworker.toml tags
 
 - `[tags].default` and per-image `tag` track the release semver (`0.2.0`).


### PR DESCRIPTION
## Summary

Follow-up to #47 addressing the four numbered review findings.

| # | Finding | Fix |
|---|---|---|
| 1 | \`aws-actions/configure-aws-credentials@v4\` — floating major tag on the AWS-cred-minting action | Pinned to \`@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4\` (the commit \`refs/tags/v4\` currently points to). Dependabot can keep this fresh. |
| 2 | OIDC audience implicit (\`sts.amazonaws.com\` is the action's default; trust policy must match) | Declared \`audience: sts.amazonaws.com\` explicitly in the workflow. Docs gained a **Trust-policy contract** section pinning the expected audience and subject pattern. |
| 3 | \`grep '^version' Cargo.toml \| head -1 \| sed -E ...\` is fragile (breaks on \`workspace.package.version\` moves, comment lines, deps that sort first) | Replaced with \`cargo metadata --no-deps --format-version 1 \| jq -r '.packages[] \| select(.name==\"oxidizedgraph\") \| .version'\`. Added an empty-version guard that exits non-zero with \`::error::\`. |
| 4 | \`vars.AWS_OIDC_ROLE_ARN != ''\` silently skips when var is missing — no signal on misconfig | New \`publish-ecr-preflight\` job runs unconditionally on push-to-main and exits 1 with an \`::error::\` annotation when the variable is empty. Existing \`publish-ecr\` \`if:\` gate stays as a short-circuit for non-main pushes / PR runs. \`publish-ecr\` now \`needs: [nix, publish-ecr-preflight]\`. |

Nits also addressed:

- Comment above \`publish-ecr\` \`if:\` line explains why vars (not secrets) are used — \"secrets can't be referenced in job-level \`if\` expressions\".
- \`role-session-name\` now includes \`\${{ github.run_attempt }}\` so retried runs are distinguishable in CloudTrail.

## What's NOT in this PR

- Trust-policy / IAM-role provisioning lives in the platform / Crossplane layer; not changed here.
- Mirroring of the ESO \`ExternalSecret\` location into \`docs/PACKAGING.md\` (nit from review) — deferred because the platform-repo path isn't known to this branch; happy to add as a one-line follow-up once you share it.

## Test plan

- [x] \`python3 -c 'import yaml; yaml.safe_load(open(\".github/workflows/validate.yml\"))'\` parses clean.
- [ ] CI \`kustomize build + kubeconform\` + \`nix build .#server-image\` green on PR.
- [ ] On a hypothetical merge with \`AWS_OIDC_ROLE_ARN\` unset, \`publish-ecr-preflight\` exits 1 with the documented \`::error::\` message; existing publish-ecr is skipped via \`needs:\`.
- [ ] On a real merge with the var set, \`publish-ecr\` runs end-to-end, the SHA-pinned action mints credentials with the explicit \`sts.amazonaws.com\` audience, and \`cargo metadata\` produces the expected \`0.2.0\` version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)