### PR TITLE
feat(deploy): EKS overlay (ECR) + amd64 nodeSelector

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,6 +47,14 @@ jobs:
       - name: kustomize build (gke-autopilot overlay)
         run: kustomize build deploy/overlays/gke-autopilot > /tmp/overlay.yaml
 
+      - name: kustomize build (eks overlay)
+        run: kustomize build deploy/overlays/eks > /tmp/eks.yaml
+
+      - name: Assert EKS overlay uses ECR image
+        run: |
+          grep -q '148080843892.dkr.ecr.us-east-2.amazonaws.com/stevedores-org/oxidizedgraph/server:0.2.0' /tmp/eks.yaml
+          grep -q 'kubernetes.io/arch: amd64' /tmp/eks.yaml
+
       - name: Assert NetworkPolicy and PDB use oxidizedgraph namespace
         run: |
           python3 <<'PY'
@@ -73,6 +81,9 @@ jobs:
 
       - name: kubeconform — overlay
         run: kubeconform -strict -summary -kubernetes-version 1.29.0 /tmp/overlay.yaml
+
+      - name: kubeconform — eks overlay
+        run: kubeconform -strict -summary -kubernetes-version 1.29.0 /tmp/eks.yaml
 
   nix:
     name: nix build .#server-image

--- a/deploy/overlays/eks/kustomization.yaml
+++ b/deploy/overlays/eks/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# EKS smoke/prod: same Autopilot hardening as gke-autopilot, image from CI ECR (linux/amd64).
+resources:
+  - ../gke-autopilot
+
+images:
+  - name: ghcr.io/stevedores-org/oxidizedgraph/server
+    newName: 148080843892.dkr.ecr.us-east-2.amazonaws.com/stevedores-org/oxidizedgraph/server
+    newTag: "0.2.0"

--- a/deploy/overlays/gke-autopilot/deployment-autopilot.yaml
+++ b/deploy/overlays/gke-autopilot/deployment-autopilot.yaml
@@ -6,6 +6,8 @@ spec:
   replicas: 2
   template:
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/docs/DEPLOY_GKE.md
+++ b/docs/DEPLOY_GKE.md
@@ -64,9 +64,19 @@ Runtime credentials (ECR pull, env, GKE WI bindings) are delivered by **External
 - **EKS**: IRSA or `imagePullSecrets` from ESO after CI pushes to ECR.
 
 ```bash
-kubectl apply -k deploy/overlays/gke-autopilot
 just deploy-eks
+# or: kubectl apply -k deploy/overlays/eks
 ```
+
+The **eks** overlay extends **gke-autopilot** and rewrites the image to ECR (`148080843892.dkr.ecr.us-east-2.amazonaws.com/stevedores-org/oxidizedgraph/server`). Pin a digest or tag before apply:
+
+```bash
+cd deploy/overlays/eks
+kustomize edit set image \
+  ghcr.io/stevedores-org/oxidizedgraph/server=148080843892.dkr.ecr.us-east-2.amazonaws.com/stevedores-org/oxidizedgraph/server:0.2.0-995a2d2
+```
+
+Mixed **arm64/amd64** node groups: the Autopilot overlay sets `nodeSelector: kubernetes.io/arch: amd64` (Nix CI images are linux/amd64).
 
 If NetworkPolicy/PDB were previously applied into `default`, delete them and re-apply the overlay.
 

--- a/justfile
+++ b/justfile
@@ -27,15 +27,15 @@ images:
 
 kustomize-check:
     kubectl kustomize deploy/overlays/gke-autopilot > /dev/null
+    kubectl kustomize deploy/overlays/eks > /dev/null
 
 deploy-gke:
     kubectl apply -k deploy/overlays/gke-autopilot
 
-# ECR image built by CI (linux/amd64). Override registry/repo via env.
+# EKS: gke-autopilot overlay + ECR image (CI publish-ecr). Override tag/registry via kustomize edit.
 ecr-registry := env_var_or_default("ECR_REGISTRY", "148080843892.dkr.ecr.us-east-2.amazonaws.com")
 ecr-image := ecr-registry + "/stevedores-org/oxidizedgraph/server:" + image-tag
 
 deploy-eks:
-    kubectl apply -k deploy/overlays/gke-autopilot
-    kubectl -n oxidizedgraph set image deployment/oxidizedgraph oxidizedgraph={{ecr-image}}
+    kubectl apply -k deploy/overlays/eks
     kubectl -n oxidizedgraph rollout status deployment/oxidizedgraph


### PR DESCRIPTION
## Summary

- **`deploy/overlays/eks`**: extends `gke-autopilot` and rewrites the image to ECR (`148080843892.dkr.ecr.us-east-2.amazonaws.com/stevedores-org/oxidizedgraph/server:0.2.0`) so `kubectl apply -k` no longer resets to private GHCR.
- **`nodeSelector: kubernetes.io/arch: amd64`** on the Autopilot deployment patch — Nix/CI images are linux/amd64; avoids `exec format error` on arm64 nodes in mixed EKS node groups.
- **`just deploy-eks`**: applies `deploy/overlays/eks` only (drops post-apply `kubectl set image`).
- **CI**: kustomize + kubeconform for the eks overlay; asserts ECR image and amd64 selector in rendered YAML.

## Test plan

- [x] `kubectl kustomize deploy/overlays/eks` — ECR image + amd64 nodeSelector
- [ ] CI `kustomize` job green on PR
- [ ] After merge: `just deploy-eks` on `steve-1-eks` — 2/2 Ready, no ImagePullBackOff
- [ ] `curl` `/health`, `/readiness`, `POST /api/v1/sessions` via port-forward


Made with [Cursor](https://cursor.com)