### PR TITLE
fix: quality gate medium-risk review routing (Issue #18 follow-up)

### DIFF
--- a/docs/ROADMAP-18.md
+++ b/docs/ROADMAP-18.md
@@ -29,9 +29,11 @@ use oxidizedgraph::prelude::*;
 let runner = TracedRunner::with_context(graph, RunContext::new(), RunnerConfig::default());
 let result = runner.invoke(AgentState::new()).await?;
 
-// Quality gate in graph
+// Quality gate in graph (routes: passed | review | needs_approval | gate_failed)
 let gate = QualityGateNode::new("quality_gate", QualityGateConfig::rust_defaults());
 ```
+
+Quality gates use `RiskClassifier::approval_route` so medium-risk changes route to a `review` edge when checks pass.
 
 ## Delivery Phases (Remaining)
 

--- a/examples/autonomous_dev_workflow.rs
+++ b/examples/autonomous_dev_workflow.rs
@@ -53,15 +53,18 @@ async fn main() -> anyhow::Result<()> {
         .add_node(QualityGateNode::new("quality_gate", gate_config))
         .add_node(StaticTransitionNode::new("ship", "done"))
         .add_node(StaticTransitionNode::new("human_review", "done"))
+        .add_node(EchoNode::new("review", "Queued for optional human review"))
         .add_node(StaticTransitionNode::new("fix_loop", "implement"))
         .add_node(EchoNode::new("done", "Workflow complete — ready to open PR"))
         .set_entry_point("implement")
         .add_edge("implement", "quality_gate")
         .add_edge_with_key("quality_gate", "ship", "passed")
         .add_edge_with_key("quality_gate", "human_review", "needs_approval")
+        .add_edge_with_key("quality_gate", "review", "review")
         .add_edge_with_key("quality_gate", "fix_loop", "gate_failed")
         .add_edge_to_end("ship")
         .add_edge_to_end("human_review")
+        .add_edge_to_end("review")
         .add_edge("fix_loop", "implement")
         .compile()?;
 

--- a/src/guardrails/gate.rs
+++ b/src/guardrails/gate.rs
@@ -204,10 +204,13 @@ impl QualityGateNode {
 
 fn truncate_log(s: &str, max: usize) -> String {
     if s.len() <= max {
-        s.to_string()
-    } else {
-        format!("{}…", &s[..max])
+        return s.to_string();
     }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &s[..end])
 }
 
 #[async_trait]
@@ -233,25 +236,19 @@ impl NodeExecutor for QualityGateNode {
             .risk_classifier
             .merge_blocker(gate_result.passed, risk);
 
+        let gates_passed_for_route =
+            gate_result.passed || !self.config.block_on_failure;
+        let route = RiskClassifier::approval_route(risk, gates_passed_for_route);
+
         {
             let mut guard = state
                 .write()
                 .map_err(|e| NodeError::execution_failed(e.to_string()))?;
             guard.set_context("gate_result", gate_result.clone());
-            guard.set_context("change_risk_level", format!("{:?}", risk));
+            guard.set_context("change_risk_level", risk);
             guard.set_context("merge_blocker", merge_blocker.clone());
             guard.set_context("gate_passed", gate_result.passed);
         }
-
-        let route = if merge_blocker.blocked {
-            if !gate_result.passed {
-                "gate_failed"
-            } else {
-                "needs_approval"
-            }
-        } else {
-            "passed"
-        };
 
         Ok(NodeOutput::transition(route))
     }
@@ -264,6 +261,7 @@ impl NodeExecutor for QualityGateNode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::guardrails::risk::RiskLevel;
     use crate::state::AgentState;
     use std::sync::RwLock;
 
@@ -330,5 +328,38 @@ mod tests {
         let state = Arc::new(RwLock::new(agent_state));
         let output = node.execute(state).await.unwrap();
         assert_eq!(output.target(), Some("needs_approval"));
+    }
+
+    #[tokio::test]
+    async fn test_medium_risk_routes_review_when_gates_pass() {
+        let config = QualityGateConfig {
+            checks: vec![CommandSpec {
+                name: "mock_check".to_string(),
+                program: "true".to_string(),
+                args: vec![],
+            }],
+            block_on_failure: true,
+        };
+        let runner = Arc::new(MockCommandRunner::new().with_result("mock_check", 0, "ok"));
+        let node = QualityGateNode::with_runner("gate", config, runner);
+
+        let mut agent_state = AgentState::new();
+        agent_state.set_context(
+            "change_risk",
+            ChangeRisk {
+                files_changed: 10,
+                used_shell: true,
+                ..Default::default()
+            },
+        );
+        let state = Arc::new(RwLock::new(agent_state));
+        let output = node.execute(state.clone()).await.unwrap();
+        assert_eq!(output.target(), Some("review"));
+
+        let guard = state.read().unwrap();
+        assert_eq!(
+            guard.get_context::<RiskLevel>("change_risk_level"),
+            Some(RiskLevel::Medium)
+        );
     }
 }

--- a/src/guardrails/risk.rs
+++ b/src/guardrails/risk.rs
@@ -88,7 +88,7 @@ impl RiskClassifier {
         }
     }
 
-    /// Transition key for routing after risk evaluation.
+    /// Transition key for routing after risk evaluation (matches graph edge keys).
     pub fn approval_route(risk: RiskLevel, gates_passed: bool) -> &'static str {
         if !gates_passed {
             return "gate_failed";
@@ -96,7 +96,7 @@ impl RiskClassifier {
         match risk {
             RiskLevel::High => "needs_approval",
             RiskLevel::Medium => "review",
-            RiskLevel::Low => "auto_continue",
+            RiskLevel::Low => "passed",
         }
     }
 }
@@ -120,5 +120,13 @@ mod tests {
         let classifier = RiskClassifier::new();
         let blocker = classifier.merge_blocker(false, RiskLevel::Low);
         assert!(blocker.blocked);
+    }
+
+    #[test]
+    fn test_approval_route_medium_risk() {
+        assert_eq!(
+            RiskClassifier::approval_route(RiskLevel::Medium, true),
+            "review"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #50 / [Issue #18](https://github.com/stevedores-org/oxidizedgraph/issues/18) Phase 1 code review:

- Route `QualityGateNode` through `RiskClassifier::approval_route` so **medium-risk** changes use the `review` transition when gates pass
- Honor `block_on_failure` when computing the routing key
- Store `RiskLevel` in agent context (instead of `Debug` formatting)
- Safe UTF-8 truncation for gate log excerpts
- Extend `autonomous_dev_workflow` example with a `review` edge/node

## Context

PR #50 (Phase 1 baseline) is already merged into `develop`. There is no PR #18 — [#18](https://github.com/stevedores-org/oxidizedgraph/issues/18) is the roadmap **issue**.

## Test plan

- [x] `cargo test guardrails`
- [ ] `cargo test`
- [ ] `cargo run --example autonomous_dev_workflow`


Made with [Cursor](https://cursor.com)