### PR TITLE
fix: CI regressions, orchestration bugs, and clippy cleanup

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,10 +9,12 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "src/**"
+      - "tests/**"
+      - "examples/**"
       - "dockworker.toml"
       - ".github/workflows/validate.yml"
   push:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: read
@@ -35,6 +37,9 @@ jobs:
 
       - name: cargo test
         run: cargo test --all-targets
+
+      - name: cargo clippy
+        run: cargo clippy --all-targets -- -D warnings
 
   kustomize:
     name: kustomize build + kubeconform
@@ -59,6 +64,20 @@ jobs:
 
       - name: kustomize build (gke-autopilot overlay)
         run: kustomize build deploy/overlays/gke-autopilot > /tmp/overlay.yaml
+
+      - name: kustomize build (eks overlay)
+        run: kustomize build deploy/overlays/eks > /tmp/eks.yaml
+
+      - name: Assert EKS overlay uses ECR image and amd64 scheduling
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name=="oxidizedgraph") | .version')
+          if [[ -z "$VERSION" ]]; then
+            echo "::error::Failed to parse package version from cargo metadata"
+            exit 1
+          fi
+          grep -q "148080843892.dkr.ecr.us-east-2.amazonaws.com/stevedores-org/oxidizedgraph/server:${VERSION}" /tmp/eks.yaml
+          grep -q 'kubernetes.io/arch: amd64' /tmp/eks.yaml
 
       - name: Assert NetworkPolicy and PDB use oxidizedgraph namespace
         run: |
@@ -86,6 +105,9 @@ jobs:
 
       - name: kubeconform — overlay
         run: kubeconform -strict -summary -kubernetes-version 1.29.0 /tmp/overlay.yaml
+
+      - name: kubeconform — eks overlay
+        run: kubeconform -strict -summary -kubernetes-version 1.29.0 /tmp/eks.yaml
 
   nix:
     name: nix build .#server-image

--- a/deploy/overlays/eks/kustomization.yaml
+++ b/deploy/overlays/eks/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# EKS smoke/prod: same Autopilot hardening as gke-autopilot, image from CI ECR (linux/amd64).
+resources:
+  - ../gke-autopilot
+
+images:
+  - name: ghcr.io/stevedores-org/oxidizedgraph/server
+    newName: 148080843892.dkr.ecr.us-east-2.amazonaws.com/stevedores-org/oxidizedgraph/server
+    newTag: "0.2.0"

--- a/deploy/overlays/gke-autopilot/deployment-autopilot.yaml
+++ b/deploy/overlays/gke-autopilot/deployment-autopilot.yaml
@@ -6,6 +6,8 @@ spec:
   replicas: 2
   template:
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/examples/autonomous_dev_workflow.rs
+++ b/examples/autonomous_dev_workflow.rs
@@ -62,9 +62,8 @@ async fn main() -> anyhow::Result<()> {
         .add_edge_with_key("quality_gate", "human_review", "needs_approval")
         .add_edge_with_key("quality_gate", "review", "review")
         .add_edge_with_key("quality_gate", "fix_loop", "gate_failed")
-        .add_edge_to_end("ship")
-        .add_edge_to_end("human_review")
-        .add_edge_to_end("review")
+        .add_edge("review", "done")
+        .add_edge_to_end("done")
         .add_edge("fix_loop", "implement")
         .compile()?;
 

--- a/examples/multi_agent.rs
+++ b/examples/multi_agent.rs
@@ -92,7 +92,7 @@ impl NodeExecutor for SynthesizerNode {
 
 fn create_researcher_graph(topic: &str, delay_ms: u64) -> CompiledGraph {
     GraphBuilder::new()
-        .name(&format!("{}_researcher", topic))
+        .name(format!("{}_researcher", topic))
         .add_node(ResearcherNode {
             id: "research".to_string(),
             topic: topic.to_string(),
@@ -207,7 +207,7 @@ async fn main() -> anyhow::Result<()> {
     let spawner = SubgraphSpawner::new();
 
     // Dynamically decide what to research based on runtime conditions
-    let topics = vec!["machine_learning", "databases", "networking"];
+    let topics = ["machine_learning", "databases", "networking"];
 
     println!("Spawning {} research tasks dynamically...", topics.len());
 

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -6,7 +6,6 @@
 //! This module will be removed in v0.3.0.
 
 use crate::state::State;
-use std::sync::Arc;
 
 /// Target specification for an edge
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -154,6 +153,8 @@ impl<S: State> Edge<S> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(deprecated)]
+
     use super::*;
     use serde::{Deserialize, Serialize};
 
@@ -169,6 +170,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_edge_target() {
         let target = EdgeTarget::node("my_node");
         assert_eq!(target.node_id(), Some("my_node"));
@@ -180,6 +182,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_direct_edge() {
         let edge: Edge<TestState> = Edge::to_node("next");
         let state = TestState::default();
@@ -188,6 +191,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_conditional_edge() {
         let edge: Edge<TestState> = Edge::conditional_fn(|s: &TestState| {
             if s.go_to_end {
@@ -221,6 +225,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_router_trait() {
         let edge: Edge<TestState> = Edge::conditional(TestRouter);
 

--- a/src/events/bus.rs
+++ b/src/events/bus.rs
@@ -45,10 +45,7 @@ impl EventBus {
     /// Returns the number of subscribers that received the event.
     /// If there are no subscribers, the event is dropped.
     pub fn publish(&self, event: Event) -> usize {
-        match self.sender.send(event) {
-            Ok(count) => count,
-            Err(_) => 0, // No active receivers
-        }
+        self.sender.send(event).unwrap_or(0)
     }
 
     /// Subscribe to events
@@ -119,10 +116,7 @@ impl EventReceiver {
     /// Returns `None` if no event is available or channel is closed.
     pub fn try_recv(&mut self) -> Option<Event> {
         let receiver = self.receiver.as_mut()?;
-        match receiver.try_recv() {
-            Ok(event) => Some(event),
-            Err(_) => None,
-        }
+        receiver.try_recv().ok()
     }
 
     /// Receive events as a stream

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -8,7 +8,7 @@ mod traced_runner;
 mod transition;
 mod validation;
 
-pub use replay::{ReplayReport, ReplayRunner};
+pub use replay::{output_from_record, ReplayReport, ReplayRunner};
 pub use traced_runner::{TracedRunResult, TracedRunner};
 pub use transition::{RunContext, TransitionLog, TransitionRecord};
 pub use validation::{StateValidator, ValidationError};

--- a/src/execution/replay.rs
+++ b/src/execution/replay.rs
@@ -2,7 +2,7 @@
 
 use crate::graph::NodeOutput;
 
-use super::transition::TransitionLog;
+use super::transition::{TransitionLog, TransitionRecord};
 
 /// Report from comparing an expected trace to an actual trace.
 #[derive(Clone, Debug, PartialEq)]
@@ -83,14 +83,27 @@ impl ReplayRunner {
     }
 }
 
-/// Stub output for replay tooling from recorded kind labels.
-#[allow(dead_code)]
-pub fn output_from_kind(kind: &str) -> NodeOutput {
-    match kind {
+/// Reconstruct node output from a recorded transition.
+pub fn output_from_record(record: &TransitionRecord) -> NodeOutput {
+    match record.output_kind.as_str() {
         "finish" => NodeOutput::finish(),
-        "continue_to" => NodeOutput::cont(),
-        "route" => NodeOutput::cont(),
-        "transition" => NodeOutput::transition("replay"),
+        "continue" => NodeOutput::cont(),
+        "continue_to" => record
+            .next_node
+            .as_ref()
+            .map(|node| NodeOutput::continue_to(node.clone()))
+            .unwrap_or_else(NodeOutput::cont),
+        "route" => record
+            .output_target
+            .as_ref()
+            .or(record.next_node.as_ref())
+            .map(|target| NodeOutput::route(target.clone()))
+            .unwrap_or_else(NodeOutput::cont),
+        "transition" => record
+            .output_target
+            .as_ref()
+            .map(|key| NodeOutput::transition(key.clone()))
+            .unwrap_or_else(|| NodeOutput::transition("unknown")),
         _ => NodeOutput::cont(),
     }
 }
@@ -99,6 +112,23 @@ pub fn output_from_kind(kind: &str) -> NodeOutput {
 mod tests {
     use super::*;
     use super::super::transition::TransitionRecord;
+
+    #[test]
+    fn test_output_from_record_preserves_transition_key() {
+        let record = TransitionRecord {
+            run_id: "r".to_string(),
+            iteration: 0,
+            node_id: "gate".to_string(),
+            output_kind: "transition".to_string(),
+            next_node: Some("ship".to_string()),
+            output_target: Some("passed".to_string()),
+            state_iteration: 1,
+            recorded_at: chrono::Utc::now(),
+        };
+
+        let output = output_from_record(&record);
+        assert_eq!(output.target(), Some("passed"));
+    }
 
     #[test]
     fn test_replay_compare_matching_logs() {

--- a/src/execution/transition.rs
+++ b/src/execution/transition.rs
@@ -74,6 +74,8 @@ pub struct TransitionRecord {
     pub output_kind: String,
     /// Next node after routing (if known)
     pub next_node: Option<String>,
+    /// Transition key or explicit route target from the node output
+    pub output_target: Option<String>,
     /// State iteration counter after this step
     pub state_iteration: usize,
     /// Timestamp when the transition was recorded
@@ -96,6 +98,7 @@ impl TransitionRecord {
             node_id: node_id.to_string(),
             output_kind: output_kind_label(output).to_string(),
             next_node: next_node.map(|s| s.to_string()),
+            output_target: output.target().map(|s| s.to_string()),
             state_iteration,
             recorded_at: Utc::now(),
         }

--- a/src/execution/validation.rs
+++ b/src/execution/validation.rs
@@ -26,6 +26,7 @@ pub enum ValidationError {
 #[derive(Clone, Debug, Default)]
 pub struct StateValidator {
     required_keys: Vec<String>,
+    typed_keys: Vec<(String, &'static str)>,
 }
 
 impl StateValidator {
@@ -40,6 +41,12 @@ impl StateValidator {
         self
     }
 
+    /// Require a context key to be present with a JSON type (`string`, `number`, etc.).
+    pub fn require_context_type(mut self, key: impl Into<String>, expected_type: &'static str) -> Self {
+        self.typed_keys.push((key.into(), expected_type));
+        self
+    }
+
     /// Validate state against required keys and optional schema checks.
     pub fn validate(&self, state: &AgentState) -> Result<(), ValidationError> {
         for key in &self.required_keys {
@@ -48,14 +55,24 @@ impl StateValidator {
             }
         }
 
-        // Ensure state conforms to AgentState schema shape when non-empty
+        for (key, expected_type) in &self.typed_keys {
+            let Some(value) = state.context.get(key) else {
+                return Err(ValidationError::MissingKey(key.clone()));
+            };
+            validate_json_type(value, expected_type).map_err(|e| match e {
+                ValidationError::InvalidValue { reason, .. } => ValidationError::InvalidValue {
+                    key: key.clone(),
+                    reason,
+                },
+                other => other,
+            })?;
+        }
+
+        // Validate top-level AgentState fields declared in the JSON schema.
         let schema = AgentState::schema();
         if let Some(required) = schema.get("required").and_then(|v| v.as_array()) {
             for item in required {
                 if let Some(prop) = item.as_str() {
-                    if prop == "context" {
-                        continue;
-                    }
                     if !state_has_property(state, prop) {
                         return Err(ValidationError::MissingKey(prop.to_string()));
                     }
@@ -79,7 +96,6 @@ fn state_has_property(state: &AgentState, prop: &str) -> bool {
 }
 
 /// Validate a JSON value against a simple type constraint.
-#[allow(dead_code)]
 pub fn validate_json_type(value: &Value, expected_type: &str) -> Result<(), ValidationError> {
     let ok = match expected_type {
         "string" => value.is_string(),
@@ -113,6 +129,28 @@ mod tests {
         ));
 
         let mut state = AgentState::new();
+        state.set_context("gate_passed", true);
+        assert!(validator.validate(&state).is_ok());
+    }
+
+    #[test]
+    fn test_schema_required_fields() {
+        let validator = StateValidator::new();
+        assert!(validator.validate(&AgentState::new()).is_ok());
+    }
+
+    #[test]
+    fn test_context_type_validation() {
+        let validator =
+            StateValidator::new().require_context_type("gate_passed", "boolean");
+
+        let mut state = AgentState::new();
+        state.set_context("gate_passed", "not-a-bool");
+        assert!(matches!(
+            validator.validate(&state),
+            Err(ValidationError::InvalidValue { .. })
+        ));
+
         state.set_context("gate_passed", true);
         assert!(validator.validate(&state).is_ok());
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -482,7 +482,7 @@ impl CompiledGraph {
         let mut output = String::from("graph TD\n");
 
         // Add nodes
-        for (id, _) in &self.node_indices {
+        for id in self.node_indices.keys() {
             if id != transitions::END {
                 output.push_str(&format!("    {}[{}]\n", id.replace('-', "_"), id));
             } else {

--- a/src/guardrails/gate.rs
+++ b/src/guardrails/gate.rs
@@ -232,13 +232,9 @@ impl NodeExecutor for QualityGateNode {
         };
 
         let risk = self.risk_classifier.classify(&change_risk);
-        let merge_blocker = self
-            .risk_classifier
-            .merge_blocker(gate_result.passed, risk);
-
-        let gates_passed_for_route =
-            gate_result.passed || !self.config.block_on_failure;
-        let route = RiskClassifier::approval_route(risk, gates_passed_for_route);
+        let effective_pass = gate_result.passed || !self.config.block_on_failure;
+        let route = RiskClassifier::approval_route(risk, effective_pass);
+        let merge_blocker = self.risk_classifier.merge_blocker(effective_pass, risk);
 
         {
             let mut guard = state
@@ -361,5 +357,30 @@ mod tests {
             guard.get_context::<RiskLevel>("change_risk_level"),
             Some(RiskLevel::Medium)
         );
+    }
+
+    #[tokio::test]
+    async fn test_non_blocking_failure_still_marks_merge_blocker() {
+        let config = QualityGateConfig {
+            checks: vec![CommandSpec {
+                name: "mock_check".to_string(),
+                program: "false".to_string(),
+                args: vec![],
+            }],
+            block_on_failure: false,
+        };
+        let runner = Arc::new(MockCommandRunner::new().with_result("mock_check", 1, "failed"));
+        let node = QualityGateNode::with_runner("gate", config, runner);
+
+        let state = Arc::new(RwLock::new(AgentState::new()));
+        let output = node.execute(state.clone()).await.unwrap();
+        assert_eq!(output.target(), Some("passed"));
+
+        let guard = state.read().unwrap();
+        assert_eq!(guard.get_context::<bool>("gate_passed"), Some(false));
+        let blocker = guard
+            .get_context::<crate::guardrails::risk::MergeBlocker>("merge_blocker")
+            .expect("merge_blocker");
+        assert!(!blocker.blocked);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! # oxidizedgraph
 //!
 //! A humble attempt at LangGraph in Rust - high-performance agent orchestration framework.
+#![cfg_attr(test, allow(deprecated))]
 //!
 //! oxidizedgraph provides graph-based agent workflows with:
 //! - **Type-safe state management** with `AgentState` and `SharedState`

--- a/src/node.rs
+++ b/src/node.rs
@@ -286,6 +286,7 @@ where
     since = "0.2.0",
     note = "This type is unused and will be removed in 0.3.0."
 )]
+#[allow(clippy::type_complexity)]
 /// A node that wraps another node with middleware-like behavior.
 pub struct WrappedNode<S: State, Inner: Node<S>> {
     inner: Inner,
@@ -353,6 +354,8 @@ impl<S: State, Inner: Node<S>> Node<S> for WrappedNode<S, Inner> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(deprecated)]
+
     use super::*;
     use serde::{Deserialize, Serialize};
 
@@ -368,6 +371,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(deprecated)]
     async fn test_node_result() {
         let state = TestState { counter: 42 };
 
@@ -386,6 +390,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(deprecated)]
     async fn test_retry_config() {
         let config = RetryConfig::new(5)
             .with_initial_delay(Duration::from_millis(50))

--- a/src/nodes/tool.rs
+++ b/src/nodes/tool.rs
@@ -499,6 +499,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_tool_node_explicit_policy_deny() {
+        use crate::tools::policy::{ToolExecutionPolicy, ToolPolicyEngine};
+
+        let tool = FunctionTool::new("rm", "remove", serde_json::json!({}), |_| Ok("ok".into()));
+        let registry = ToolRegistry::new().register(tool);
+        let policy = ToolPolicyEngine::new(ToolExecutionPolicy::permissive().deny_tool("rm"));
+        let config = ToolNodeConfig::default().with_policy(policy);
+        let node = ToolNode::with_config("tools", registry, config);
+
+        let mut state = AgentState::new();
+        state
+            .tool_calls
+            .push(ToolCall::new("1", "rm", serde_json::json!({})));
+
+        let shared = Arc::new(RwLock::new(state));
+        node.execute(shared.clone()).await.unwrap();
+        let guard = shared.read().unwrap();
+        assert!(guard.messages[0].content.contains("denied by policy"));
+    }
+
+    #[tokio::test]
     async fn test_tool_node_policy_denial() {
         use crate::tools::policy::{ToolExecutionPolicy, ToolPolicyEngine};
 

--- a/src/orchestration/parallel.rs
+++ b/src/orchestration/parallel.rs
@@ -305,6 +305,19 @@ impl NodeExecutor for ParallelSubgraphs {
         // Execute all subgraphs
         let results = self.execute_all(&parent_state).await;
 
+        if let Some((id, result)) = results.iter().find(|(_, r)| r.is_failed()) {
+            let message = match result {
+                SubgraphResult::Failed { error, .. } => {
+                    format!("Subgraph '{id}' failed: {error}")
+                }
+                SubgraphResult::Cancelled { .. } => {
+                    format!("Subgraph '{id}' was cancelled")
+                }
+                _ => format!("Subgraph '{id}' failed"),
+            };
+            return Err(NodeError::execution_failed(message));
+        }
+
         debug!(
             node_id = %self.id,
             completed = results.iter().filter(|(_, r)| r.is_completed()).count(),
@@ -433,11 +446,30 @@ mod tests {
 
         let state = Arc::new(RwLock::new(AgentState::new()));
         let start = Instant::now();
-        let _ = parallel.execute(state).await.unwrap();
+        let result = parallel.execute(state).await;
         let elapsed = start.elapsed();
 
+        assert!(result.is_err());
         // Should return quickly due to fail-fast, not wait for the 1000ms subgraph
         assert!(elapsed < Duration::from_millis(900));
+    }
+
+    #[tokio::test]
+    async fn test_parallel_wait_all_propagates_failure() {
+        let parallel = ParallelSubgraphs::new("parallel")
+            .add_subgraph("ok", create_delayed_graph("ok", "k", "v", 10))
+            .add_subgraph("fail", GraphBuilder::new()
+                .add_node(crate::nodes::function::FunctionNode::new("fail", |_| async {
+                    Err(NodeError::execution_failed("intentional failure"))
+                }))
+                .set_entry_point("fail")
+                .compile()
+                .unwrap())
+            .with_join_strategy(JoinStrategy::WaitAll);
+
+        let state = Arc::new(RwLock::new(AgentState::new()));
+        let result = parallel.execute(state).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src/orchestration/parallel.rs
+++ b/src/orchestration/parallel.rs
@@ -24,7 +24,10 @@ pub enum JoinStrategy {
     WaitFirst,
     /// Return as soon as any subgraph fails (fail-fast)
     FailFast,
-    /// Wait for a specific number of subgraphs to complete
+    /// Return once `n` subgraphs complete successfully; abort the rest.
+    ///
+    /// Failed or cancelled subgraphs do not count toward `n`. The first failure
+    /// aborts remaining work and returns immediately (same as [`JoinStrategy::FailFast`]).
     WaitN(usize),
 }
 
@@ -255,6 +258,13 @@ impl ParallelSubgraphs {
             JoinStrategy::WaitN(n) => {
                 let mut completed = 0;
                 while let Some((id, result)) = futures.next().await {
+                    if result.is_failed() {
+                        results.push((id, result));
+                        for handle in abort_handles {
+                            handle.abort();
+                        }
+                        return results;
+                    }
                     if result.is_completed() {
                         completed += 1;
                     }
@@ -485,6 +495,49 @@ mod tests {
         let elapsed = start.elapsed();
 
         // Should return quickly after the first one finishes
+        assert!(elapsed < Duration::from_millis(900));
+    }
+
+    #[tokio::test]
+    async fn test_parallel_wait_n_returns_after_n_successes() {
+        let parallel = ParallelSubgraphs::new("parallel")
+            .add_subgraph("fast", create_delayed_graph("fast", "fast", "v", 10))
+            .add_subgraph("medium", create_delayed_graph("medium", "medium", "v", 30))
+            .add_subgraph("slow", create_delayed_graph("slow", "slow", "v", 1000))
+            .with_join_strategy(JoinStrategy::WaitN(2));
+
+        let state = Arc::new(RwLock::new(AgentState::new()));
+        let start = Instant::now();
+        parallel.execute(state.clone()).await.unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(elapsed < Duration::from_millis(900));
+        let guard = state.read().unwrap();
+        assert!(guard.context.contains_key("fast"));
+        assert!(guard.context.contains_key("medium"));
+        assert!(!guard.context.contains_key("slow"));
+    }
+
+    #[tokio::test]
+    async fn test_parallel_wait_n_fail_fast_on_error() {
+        let parallel = ParallelSubgraphs::new("parallel")
+            .add_subgraph("ok", create_delayed_graph("ok", "ok", "v", 10))
+            .add_subgraph("fail", GraphBuilder::new()
+                .add_node(crate::nodes::function::FunctionNode::new("fail", |_| async {
+                    Err(NodeError::execution_failed("intentional failure"))
+                }))
+                .set_entry_point("fail")
+                .compile()
+                .unwrap())
+            .add_subgraph("slow", create_delayed_graph("slow", "slow", "v", 1000))
+            .with_join_strategy(JoinStrategy::WaitN(2));
+
+        let state = Arc::new(RwLock::new(AgentState::new()));
+        let start = Instant::now();
+        let result = parallel.execute(state).await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err());
         assert!(elapsed < Duration::from_millis(900));
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -193,6 +193,7 @@ impl State for AgentState {
     fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
+            "required": ["messages", "tool_calls", "context"],
             "properties": {
                 "messages": { "type": "array", "channel": "append" },
                 "tool_calls": { "type": "array" },

--- a/src/tools/policy.rs
+++ b/src/tools/policy.rs
@@ -114,11 +114,7 @@ impl ToolPolicyEngine {
     /// Evaluate whether a tool may run.
     pub fn evaluate(&self, tool_name: &str, command_hint: Option<&str>) -> Result<PolicyDecision, PolicyViolation> {
         if self.policy.denied_tools.contains(tool_name) {
-            return Err(PolicyViolation {
-                tool_name: tool_name.to_string(),
-                reason: "tool is explicitly denied".to_string(),
-                capability: None,
-            });
+            return Ok(PolicyDecision::Deny);
         }
 
         if self.policy.approval_required.contains(tool_name) {
@@ -153,6 +149,13 @@ impl ToolPolicyEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_explicit_deny_tool() {
+        let policy = ToolExecutionPolicy::permissive().deny_tool("rm");
+        let engine = ToolPolicyEngine::new(policy);
+        assert_eq!(engine.evaluate("rm", None).unwrap(), PolicyDecision::Deny);
+    }
 
     #[test]
     fn test_deny_unknown_tool() {

--- a/src/tools/sandbox.rs
+++ b/src/tools/sandbox.rs
@@ -105,7 +105,11 @@ impl SandboxExecutor for SubprocessSandbox {
         }
 
         let mut cmd = Command::new("sh");
-        cmd.arg("-c").arg(command).stdout(Stdio::piped()).stderr(Stdio::piped());
+        cmd.arg("-c")
+            .arg(command)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
         if let Some(dir) = working_dir {
             cmd.current_dir(dir);
         }


### PR DESCRIPTION
## Summary

- Restore **EKS overlay** (`deploy/overlays/eks/`) and kustomize/kubeconform CI steps that were on `main` but missing from `develop`
- Add **`amd64` nodeSelector** to the GKE Autopilot deployment overlay
- Fix orchestration bugs:
  - `ParallelSubgraphs` now returns `Err` when any subgraph fails (was silently succeeding)
  - `QualityGateNode` uses the same effective pass flag for routing and `merge_blocker` when `block_on_failure = false`
  - `output_from_record` reconstructs transition keys/targets from `TransitionRecord` (fixes broken replay helper)
  - `autonomous_dev_workflow` example routes medium-risk `review` through the `done` node
  - Subprocess sandbox sets `kill_on_drop(true)` so timed-out commands do not leak
- Harden CI: clippy in `validate`, trigger on `develop` pushes, include `tests/**` and `examples/**` in path filters

## Test plan

- [x] `cargo test --all-targets` (121 tests)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo run --example autonomous_dev_workflow` (4 transitions, ends at `done`)


Made with [Cursor](https://cursor.com)