### PR TITLE
feat(governance): foundation types — AgentRole + manifest tag parser (slice of #31)

### DIFF
--- a/src/governance/mod.rs
+++ b/src/governance/mod.rs
@@ -1,0 +1,37 @@
+//! Governance: role-scoped guidance parsed from the master manifest.
+//!
+//! This module is the foundation slice of [issue #31][issue]. It provides
+//! the parse layer used by every other governance feature: the
+//! [`AgentRole`] enum and a tag-block parser that turns an `AGENTS.md`-
+//! style manifest into role-scoped [`TaggedBlock`]s.
+//!
+//! Higher-level pieces (config loading, `GovernanceNode`, state
+//! integration) build on these primitives in follow-up PRs.
+//!
+//! [issue]: https://github.com/stevedores-org/oxidizedgraph/issues/31
+//!
+//! # Quick start
+//!
+//! ```
+//! use oxidizedgraph::governance::{parse_blocks, blocks_for, AgentRole};
+//!
+//! let manifest = "\
+//! <@all>
+//! Read AGENTS.md before changing anything.
+//! <@builder>
+//! Run local-ci before pushing.
+//! ";
+//!
+//! let blocks = parse_blocks(manifest);
+//! let builder_view: Vec<_> = blocks_for(&blocks, &AgentRole::Builder).collect();
+//! // The builder sees both the broadcast and its own block, in source order.
+//! assert_eq!(builder_view.len(), 2);
+//! assert_eq!(builder_view[0].role, AgentRole::All);
+//! assert_eq!(builder_view[1].role, AgentRole::Builder);
+//! ```
+
+pub mod parser;
+pub mod roles;
+
+pub use parser::{blocks_for, parse_blocks, TaggedBlock};
+pub use roles::{AgentRole, RoleParseError};

--- a/src/governance/parser.rs
+++ b/src/governance/parser.rs
@@ -1,0 +1,258 @@
+//! Tag-block parser for `AGENTS.md`-style governance manifests.
+//!
+//! The manifest is plain Markdown sprinkled with inline role tags like
+//! `<@all>` or `<@builder>`. A tag opens a *block* whose body runs from
+//! the line **after** the tag up to (but not including) the next role
+//! tag, or to end-of-input. The same tag can appear multiple times in
+//! one manifest; each occurrence becomes a separate [`TaggedBlock`].
+//!
+//! This parser is the source of truth for "which lines belong to which
+//! role." It is deliberately minimal:
+//!
+//! * lossless — every non-tag line lands in exactly one block;
+//! * order-preserving — blocks come back in manifest order;
+//! * tag-greedy on the same line — a line that contains only a tag (and
+//!   optional surrounding whitespace) becomes the boundary; a line that
+//!   contains a tag mid-prose is treated as body, not a boundary.
+//!
+//! Higher layers (filtering by role, applying rule lookups) build on
+//! [`parse_blocks`] without re-implementing the scan.
+
+use crate::governance::roles::AgentRole;
+use std::str::FromStr;
+
+/// One contiguous region of a manifest scoped to a single role.
+///
+/// `content` is the raw text between this tag boundary and the next,
+/// with surrounding blank lines preserved so the block is byte-faithful.
+/// Use `content.trim()` if you want the visually-trimmed form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaggedBlock {
+    /// The role this block is scoped to.
+    pub role: AgentRole,
+    /// 1-indexed line in the source where the opening `<@tag>` lives.
+    pub tag_line: usize,
+    /// Lines belonging to this block (between this tag and the next).
+    pub content: String,
+}
+
+/// Parse a manifest into role-scoped blocks.
+///
+/// Lines before the first tag are dropped — the parser only emits
+/// blocks that have an explicit role attached. If you need a "preamble"
+/// region, prepend an `<@all>` tag in the source.
+///
+/// Unparseable tags (e.g. `<@ >`, `<@bad char>`) are silently ignored
+/// and their would-be opening line is treated as body of the previous
+/// block. This is intentional — `<@ >` is more likely a typo than a
+/// real boundary, and silently dropping it preserves the rest of the
+/// manifest's structure for downstream consumers.
+pub fn parse_blocks(input: &str) -> Vec<TaggedBlock> {
+    let mut blocks: Vec<TaggedBlock> = Vec::new();
+    let mut current: Option<TaggedBlock> = None;
+
+    for (idx, line) in input.lines().enumerate() {
+        let line_no = idx + 1;
+        if let Some(role) = parse_tag_line(line) {
+            // Tag boundary — flush the previous block (if any) and start a
+            // fresh one. Empty trailing newlines on the previous block are
+            // intentionally preserved so the source text round-trips.
+            if let Some(prev) = current.take() {
+                blocks.push(prev);
+            }
+            current = Some(TaggedBlock {
+                role,
+                tag_line: line_no,
+                content: String::new(),
+            });
+        } else if let Some(block) = current.as_mut() {
+            // Body line of the current block.
+            if !block.content.is_empty() {
+                block.content.push('\n');
+            }
+            block.content.push_str(line);
+        }
+        // Lines before the first tag have no owner; drop them.
+    }
+    if let Some(prev) = current {
+        blocks.push(prev);
+    }
+    blocks
+}
+
+/// Iterate the blocks scoped to a specific role.
+///
+/// Semantics:
+/// * `target == All` returns every block — `All` is the universal listener,
+///   useful for diagnostics / dumping the manifest.
+/// * A concrete `target` returns blocks tagged with that role plus
+///   blocks tagged `<@all>` (the broadcast).
+///
+/// This is intentionally *more permissive* than `AgentRole::receives` for
+/// the `All` case: when you ask "what blocks apply to role X?" you want
+/// X's blocks plus broadcasts; when you ask "show me everything", you
+/// expect everything.
+pub fn blocks_for<'a>(
+    blocks: &'a [TaggedBlock],
+    target: &'a AgentRole,
+) -> impl Iterator<Item = &'a TaggedBlock> {
+    blocks.iter().filter(move |b| match target {
+        AgentRole::All => true,
+        other => b.role == AgentRole::All || &b.role == other,
+    })
+}
+
+/// If `line` is *exactly* a role tag (optional surrounding whitespace
+/// only), return the parsed role. A line like `prose <@builder> more
+/// prose` returns `None` — the tag must own the line to count as a
+/// block boundary, mirroring how `AGENTS.md` actually uses these.
+fn parse_tag_line(line: &str) -> Option<AgentRole> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with("<@") || !trimmed.ends_with('>') {
+        return None;
+    }
+    // strip prefix/suffix and feed FromStr; FromStr re-handles the
+    // decoration but accepts the inner form directly too. Both error
+    // variants are equally "not a real boundary" — discard them.
+    let inner = &trimmed[2..trimmed.len() - 1];
+    AgentRole::from_str(inner).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_single_block() {
+        let input = "<@all>\nhello\nworld\n";
+        let blocks = parse_blocks(input);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].role, AgentRole::All);
+        assert_eq!(blocks[0].tag_line, 1);
+        assert_eq!(blocks[0].content, "hello\nworld");
+    }
+
+    #[test]
+    fn splits_on_each_tag() {
+        let input =
+            "<@architect>\ndesign things\n<@builder>\nbuild things\n<@auditor>\naudit things\n";
+        let blocks = parse_blocks(input);
+        assert_eq!(blocks.len(), 3);
+        let roles: Vec<_> = blocks.iter().map(|b| b.role.clone()).collect();
+        assert_eq!(
+            roles,
+            vec![AgentRole::Architect, AgentRole::Builder, AgentRole::Auditor]
+        );
+        assert_eq!(blocks[0].content, "design things");
+        assert_eq!(blocks[1].content, "build things");
+        assert_eq!(blocks[2].content, "audit things");
+    }
+
+    #[test]
+    fn drops_preamble_before_first_tag() {
+        // Anything before the first <@role> tag has no owner — drop it.
+        let input = "preamble line one\npreamble line two\n<@builder>\nbody\n";
+        let blocks = parse_blocks(input);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].content, "body");
+    }
+
+    #[test]
+    fn preserves_block_order_with_repeated_tags() {
+        let input = "<@all>\nintro\n<@builder>\nfirst builder\n<@all>\nbetween broadcast\n<@builder>\nsecond builder\n";
+        let blocks = parse_blocks(input);
+        assert_eq!(blocks.len(), 4);
+        assert_eq!(
+            blocks.iter().map(|b| b.role.clone()).collect::<Vec<_>>(),
+            vec![
+                AgentRole::All,
+                AgentRole::Builder,
+                AgentRole::All,
+                AgentRole::Builder
+            ]
+        );
+        // The 4 contents must keep the source order intact.
+        assert_eq!(blocks[0].content, "intro");
+        assert_eq!(blocks[1].content, "first builder");
+        assert_eq!(blocks[2].content, "between broadcast");
+        assert_eq!(blocks[3].content, "second builder");
+    }
+
+    #[test]
+    fn mid_line_tag_is_not_a_boundary() {
+        // Real prose may mention a tag mid-sentence; that must not split
+        // the block, otherwise documentation about tags would be unreadable.
+        let input =
+            "<@all>\nThe <@builder> role is for implementation.\n<@builder>\nactual builder body\n";
+        let blocks = parse_blocks(input);
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0].role, AgentRole::All);
+        assert!(
+            blocks[0].content.contains("<@builder>"),
+            "mid-line tag should stay in the @all block, got: {:?}",
+            blocks[0].content
+        );
+        assert_eq!(blocks[1].role, AgentRole::Builder);
+        assert_eq!(blocks[1].content, "actual builder body");
+    }
+
+    #[test]
+    fn unknown_tags_become_custom_blocks() {
+        let input = "<@codex>\ntool-specific\n<@sdlc>\ndomain-specific\n";
+        let blocks = parse_blocks(input);
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0].role, AgentRole::Custom("codex".to_string()));
+        assert_eq!(blocks[1].role, AgentRole::Custom("sdlc".to_string()));
+    }
+
+    #[test]
+    fn malformed_tag_is_silently_ignored() {
+        // <@ > is an empty tag; it should not become a boundary, and the
+        // existing block continues unbroken.
+        let input = "<@builder>\nfirst\n<@ >\nsecond\n";
+        let blocks = parse_blocks(input);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].role, AgentRole::Builder);
+        // The malformed line and the line after it both become body.
+        assert!(blocks[0].content.contains("first"));
+        assert!(blocks[0].content.contains("<@ >"));
+        assert!(blocks[0].content.contains("second"));
+    }
+
+    #[test]
+    fn blocks_for_filters_by_role_with_broadcast() {
+        let input = "<@all>\nbroadcast\n<@builder>\nbuilder only\n<@auditor>\nauditor only\n";
+        let blocks = parse_blocks(input);
+
+        let builder_view: Vec<_> = blocks_for(&blocks, &AgentRole::Builder)
+            .map(|b| b.content.as_str())
+            .collect();
+        assert_eq!(builder_view, vec!["broadcast", "builder only"]);
+
+        let auditor_view: Vec<_> = blocks_for(&blocks, &AgentRole::Auditor)
+            .map(|b| b.content.as_str())
+            .collect();
+        assert_eq!(auditor_view, vec!["broadcast", "auditor only"]);
+
+        // Targeting `All` gives every block back.
+        let all_view: Vec<_> = blocks_for(&blocks, &AgentRole::All)
+            .map(|b| b.content.as_str())
+            .collect();
+        assert_eq!(all_view, vec!["broadcast", "builder only", "auditor only"]);
+    }
+
+    #[test]
+    fn empty_input_yields_no_blocks() {
+        assert!(parse_blocks("").is_empty());
+        assert!(parse_blocks("\n\n\n").is_empty());
+        assert!(parse_blocks("only prose, no tags\nat all\n").is_empty());
+    }
+
+    #[test]
+    fn tag_line_numbers_are_one_indexed() {
+        let input = "<@all>\nbody-line-2\n<@builder>\nbody-line-4\n";
+        let blocks = parse_blocks(input);
+        assert_eq!(blocks[0].tag_line, 1);
+        assert_eq!(blocks[1].tag_line, 3);
+    }
+}

--- a/src/governance/roles.rs
+++ b/src/governance/roles.rs
@@ -1,0 +1,236 @@
+//! Agent roles for governance tag routing.
+//!
+//! The repo's `AGENTS.md` master manifest uses inline tags such as `<@all>`,
+//! `<@architect>`, and `<@builder>` to scope a block of guidance to one or
+//! more agent roles. This module defines the canonical [`AgentRole`] enum
+//! and the parse helpers that turn a raw tag name (the part between `<@`
+//! and `>`) into a typed role.
+//!
+//! The four roles in the issue spec (`Architect`, `Builder`, `Auditor`,
+//! `Human`) are first-class variants. Everything else — tool tags like
+//! `<@codex>` / `<@gemini>`, domain tags like `<@sdlc>`, the broadcast
+//! `<@all>` — is preserved as either [`AgentRole::All`] or
+//! [`AgentRole::Custom`] so the parser is lossless against the real
+//! manifest. Higher layers decide what to do with each role.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// A governance-scoped agent role parsed from an `<@role>` tag.
+///
+/// `All` is the broadcast tag (`<@all>`). The four named variants are the
+/// canonical roles called out in issue #31; `Custom` carries any other
+/// tag (tool names, domain tags) verbatim so no information is lost.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRole {
+    /// `<@all>` — guidance applies to every agent role.
+    All,
+    /// `<@architect>` — design / planning / API-shape decisions.
+    Architect,
+    /// `<@builder>` — implementation / refactor / bugfix.
+    Builder,
+    /// `<@auditor>` — review / verification / quality gates.
+    Auditor,
+    /// `<@human>` — explicitly addressed to the human-in-the-loop.
+    Human,
+    /// Any other tag (e.g. `<@codex>`, `<@sdlc>`). The string is the
+    /// lowercase tag content with no `<@` / `>` decoration.
+    Custom(String),
+}
+
+impl AgentRole {
+    /// Returns the canonical lowercase tag name for this role, without the
+    /// surrounding `<@` / `>`.
+    pub fn as_tag(&self) -> &str {
+        match self {
+            Self::All => "all",
+            Self::Architect => "architect",
+            Self::Builder => "builder",
+            Self::Auditor => "auditor",
+            Self::Human => "human",
+            Self::Custom(s) => s.as_str(),
+        }
+    }
+
+    /// True if `self` should receive guidance addressed to `target`.
+    ///
+    /// Routing is asymmetric: the broadcast role `All` matches every
+    /// concrete role *when it is the target*, but a concrete role does
+    /// **not** match `All` when `All` is the listener. This mirrors how
+    /// `<@all>` is used in `AGENTS.md`: blocks tagged `<@all>` reach
+    /// every agent, but a `<@builder>` block does not also leak into an
+    /// `All`-scoped subscriber.
+    pub fn receives(&self, target: &AgentRole) -> bool {
+        target == &AgentRole::All || self == target
+    }
+}
+
+impl fmt::Display for AgentRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "<@{}>", self.as_tag())
+    }
+}
+
+/// Error returned when a tag string can't be coerced into an [`AgentRole`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RoleParseError {
+    /// The input was empty or contained only whitespace.
+    #[error("agent role tag is empty")]
+    Empty,
+    /// The input contained characters not allowed in a tag (whitespace,
+    /// angle brackets, etc.). Tags must be `[a-z0-9_-]+` after lowercasing.
+    #[error("agent role tag '{0}' contains invalid characters (allowed: a-z, 0-9, _, -)")]
+    InvalidCharacter(String),
+}
+
+impl FromStr for AgentRole {
+    type Err = RoleParseError;
+
+    /// Parse a tag from its raw form — accepts the inner name (`builder`)
+    /// or the fully-tagged form (`<@builder>` / `@builder`), case
+    /// insensitively. Unknown but well-formed tags become
+    /// [`AgentRole::Custom`].
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err(RoleParseError::Empty);
+        }
+        // Strip optional `<@...>` or `@...` decoration so callers can pass
+        // either form. We only strip the outermost layer; nested angle
+        // brackets fall through to the InvalidCharacter check below.
+        let inner = trimmed
+            .strip_prefix("<@")
+            .and_then(|s| s.strip_suffix('>'))
+            .or_else(|| trimmed.strip_prefix('@'))
+            .unwrap_or(trimmed);
+
+        let lower = inner.to_ascii_lowercase();
+        if lower.is_empty() {
+            return Err(RoleParseError::Empty);
+        }
+        if !lower
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
+        {
+            return Err(RoleParseError::InvalidCharacter(lower));
+        }
+
+        Ok(match lower.as_str() {
+            "all" => Self::All,
+            "architect" => Self::Architect,
+            "builder" => Self::Builder,
+            "auditor" => Self::Auditor,
+            "human" => Self::Human,
+            _ => Self::Custom(lower),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_canonical_roles() {
+        assert_eq!("all".parse::<AgentRole>().unwrap(), AgentRole::All);
+        assert_eq!(
+            "architect".parse::<AgentRole>().unwrap(),
+            AgentRole::Architect
+        );
+        assert_eq!("builder".parse::<AgentRole>().unwrap(), AgentRole::Builder);
+        assert_eq!("auditor".parse::<AgentRole>().unwrap(), AgentRole::Auditor);
+        assert_eq!("human".parse::<AgentRole>().unwrap(), AgentRole::Human);
+    }
+
+    #[test]
+    fn accepts_decorated_forms() {
+        assert_eq!(
+            "<@builder>".parse::<AgentRole>().unwrap(),
+            AgentRole::Builder
+        );
+        assert_eq!("@builder".parse::<AgentRole>().unwrap(), AgentRole::Builder);
+        assert_eq!(
+            "  @architect  ".parse::<AgentRole>().unwrap(),
+            AgentRole::Architect
+        );
+    }
+
+    #[test]
+    fn is_case_insensitive() {
+        assert_eq!(
+            "Architect".parse::<AgentRole>().unwrap(),
+            AgentRole::Architect
+        );
+        assert_eq!("BUILDER".parse::<AgentRole>().unwrap(), AgentRole::Builder);
+        assert_eq!("<@HUMAN>".parse::<AgentRole>().unwrap(), AgentRole::Human);
+    }
+
+    #[test]
+    fn preserves_unknown_tags_as_custom() {
+        let codex: AgentRole = "<@codex>".parse().unwrap();
+        assert_eq!(codex, AgentRole::Custom("codex".to_string()));
+        let sdlc: AgentRole = "sdlc".parse().unwrap();
+        assert_eq!(sdlc, AgentRole::Custom("sdlc".to_string()));
+    }
+
+    #[test]
+    fn rejects_empty_and_whitespace() {
+        assert_eq!("".parse::<AgentRole>(), Err(RoleParseError::Empty));
+        assert_eq!("   ".parse::<AgentRole>(), Err(RoleParseError::Empty));
+        assert_eq!("<@>".parse::<AgentRole>(), Err(RoleParseError::Empty));
+    }
+
+    #[test]
+    fn rejects_invalid_characters() {
+        // Spaces, uppercase non-ASCII, punctuation in the tag body.
+        assert!(matches!(
+            "two words".parse::<AgentRole>(),
+            Err(RoleParseError::InvalidCharacter(_))
+        ));
+        assert!(matches!(
+            "build.er".parse::<AgentRole>(),
+            Err(RoleParseError::InvalidCharacter(_))
+        ));
+    }
+
+    #[test]
+    fn display_round_trips() {
+        for role in [
+            AgentRole::All,
+            AgentRole::Architect,
+            AgentRole::Builder,
+            AgentRole::Auditor,
+            AgentRole::Human,
+            AgentRole::Custom("codex".to_string()),
+        ] {
+            // `<@role>` formatting parses back to the same role.
+            let rendered = role.to_string();
+            let parsed: AgentRole = rendered.parse().unwrap();
+            assert_eq!(role, parsed, "round-trip failed for {role}");
+        }
+    }
+
+    #[test]
+    fn receives_routing_semantics() {
+        // Every concrete role receives broadcasts addressed to `All`.
+        for role in [
+            AgentRole::Architect,
+            AgentRole::Builder,
+            AgentRole::Auditor,
+            AgentRole::Human,
+            AgentRole::Custom("codex".into()),
+        ] {
+            assert!(
+                role.receives(&AgentRole::All),
+                "{role} should receive <@all>"
+            );
+        }
+        // A concrete tag does NOT leak into a different concrete subscriber.
+        assert!(!AgentRole::Builder.receives(&AgentRole::Architect));
+        // `All` subscribers do NOT pick up concrete-role traffic — that
+        // would defeat the point of role-scoped guidance.
+        assert!(!AgentRole::All.receives(&AgentRole::Builder));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod error;
 pub mod events;
 pub mod execution;
 pub mod git;
+pub mod governance;
 pub mod graph;
 pub mod guardrails;
 pub mod nodes;

--- a/tests/governance_types.rs
+++ b/tests/governance_types.rs
@@ -1,0 +1,117 @@
+//! Integration tests for the governance foundation types (issue #31, slice 1).
+//!
+//! Unit tests for individual parsing rules live next to the source in
+//! `src/governance/{roles,parser}.rs`. The tests here exercise the
+//! public API surface (`oxidizedgraph::governance::*`) and validate
+//! end-to-end behavior on inputs that look like real `AGENTS.md` files.
+
+use oxidizedgraph::governance::{blocks_for, parse_blocks, AgentRole};
+
+/// A realistic-shape manifest slice: broadcast preamble, then several
+/// role-scoped blocks including tool tags this repo actually uses.
+const SAMPLE_MANIFEST: &str = "\
+<@all>
+# Repo conventions
+Run `local-ci` before pushing.
+
+<@architect>
+Bias toward the existing `NodeExecutor` trait. Don't add a parallel
+abstraction for `GovernanceNode`.
+
+<@builder>
+Run `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings`
+before each commit.
+
+<@auditor>
+Reject PRs that introduce new modules without doc comments
+(`#![warn(missing_docs)]` is on at the crate root).
+
+<@codex>
+Tool-specific guidance for the Codex agent goes here.
+";
+
+#[test]
+fn parses_real_shape_manifest_into_five_blocks() {
+    let blocks = parse_blocks(SAMPLE_MANIFEST);
+    assert_eq!(
+        blocks.len(),
+        5,
+        "expected one block per <@role> tag, got {}",
+        blocks.len()
+    );
+    let roles: Vec<_> = blocks.iter().map(|b| b.role.clone()).collect();
+    assert_eq!(
+        roles,
+        vec![
+            AgentRole::All,
+            AgentRole::Architect,
+            AgentRole::Builder,
+            AgentRole::Auditor,
+            AgentRole::Custom("codex".into()),
+        ]
+    );
+}
+
+#[test]
+fn builder_view_includes_broadcast_and_own_block_only() {
+    let blocks = parse_blocks(SAMPLE_MANIFEST);
+    let view: Vec<_> = blocks_for(&blocks, &AgentRole::Builder).collect();
+
+    assert_eq!(view.len(), 2, "builder should see <@all> + <@builder> only");
+    assert_eq!(view[0].role, AgentRole::All);
+    assert_eq!(view[1].role, AgentRole::Builder);
+    assert!(view[1].content.contains("cargo fmt"));
+}
+
+#[test]
+fn custom_role_view_does_not_pick_up_canonical_blocks() {
+    let blocks = parse_blocks(SAMPLE_MANIFEST);
+    let codex = AgentRole::Custom("codex".into());
+    let view: Vec<_> = blocks_for(&blocks, &codex).collect();
+
+    // Custom role should still see broadcasts, plus its own block.
+    let role_seq: Vec<_> = view.iter().map(|b| b.role.clone()).collect();
+    assert_eq!(role_seq, vec![AgentRole::All, codex.clone()]);
+    // No leakage from <@builder>/<@architect>/<@auditor>.
+    assert!(view
+        .iter()
+        .all(|b| b.role == AgentRole::All || b.role == codex));
+}
+
+#[test]
+fn round_trip_role_tags_are_canonical() {
+    // Every canonical role's Display form must parse back to the same role
+    // — this is the contract `GovernanceNode` will rely on for routing.
+    for role in [
+        AgentRole::All,
+        AgentRole::Architect,
+        AgentRole::Builder,
+        AgentRole::Auditor,
+        AgentRole::Human,
+    ] {
+        let rendered = role.to_string();
+        let parsed: AgentRole = rendered.parse().expect("canonical roles must round-trip");
+        assert_eq!(role, parsed);
+    }
+}
+
+#[test]
+fn empty_manifest_yields_no_blocks() {
+    assert!(parse_blocks("").is_empty());
+    assert!(parse_blocks("\n\n").is_empty());
+}
+
+#[test]
+fn parser_is_lossless_within_a_block() {
+    // The exact bytes between two tag lines must survive parsing. This is
+    // the contract that lets a future `guidance.rs` slice content out
+    // verbatim (e.g. for diffing against the prior manifest).
+    let manifest =
+        "<@builder>\nline-A\n  indented\n\n  blank-line above\nline-B\n<@auditor>\nother\n";
+    let blocks = parse_blocks(manifest);
+    assert_eq!(blocks.len(), 2);
+    assert_eq!(
+        blocks[0].content,
+        "line-A\n  indented\n\n  blank-line above\nline-B"
+    );
+}


### PR DESCRIPTION
First slice of [#31 Phase 1: Governance Foundation](https://github.com/stevedores-org/oxidizedgraph/issues/31). Lands the parse layer every other governance feature will depend on, in a scope small enough to review in one sitting.

## What this adds

| File | Purpose |
|---|---|
| `src/governance/mod.rs` | Module wiring + public re-exports + doctest quick-start |
| `src/governance/roles.rs` | `AgentRole` enum + `FromStr`/`Display` + `receives` routing rule + `RoleParseError` |
| `src/governance/parser.rs` | `parse_blocks` (manifest → ordered `TaggedBlock` list) + `blocks_for` (role-scoped view) |
| `src/lib.rs` | One-line: `pub mod governance;` |
| `tests/governance_types.rs` | Integration tests on a realistic `AGENTS.md`-shape input |

## Design choices worth flagging

**Lossless `AgentRole::Custom(String)`.** The issue spec lists four canonical roles (Architect, Builder, Auditor, Human). The actual `AGENTS.md` in this repo uses many more tags — `<@codex>`, `<@gemini>`, `<@copilot>`, `<@cursor>`, `<@jules>`, `<@antigravity>`, `<@sdlc>`. Rather than dropping those on the floor, the parser keeps them as `Custom("codex")` etc. so a future tool-dispatch layer can opt into them without rewriting the parser.

**Asymmetric routing between `receives` and `blocks_for`.** `AgentRole::receives(other)` answers "should a listener of `self` pick up a message addressed to `other`?" — concrete roles pick up `All` broadcasts but `All` does not silently consume concrete-role traffic. `blocks_for(target == All)`, however, returns every block — that's a *view* operation for diagnostics / dumping, not a routing decision. Both are documented inline so the asymmetry isn't a surprise.

**Mid-line tags are prose, not boundaries.** Documentation that mentions `<@builder>` in the middle of a sentence (like the surrounding `AGENTS.md` itself) must not split the block. The parser only treats a tag as a boundary when it owns the entire line (with optional surrounding whitespace).

## Deferred from the Phase 1 checklist

The full Phase 1 calls for 8 governance files plus `GovernanceNode` and a `state.rs` extension. Those depend on either a new dependency (`serde_yaml` for `config.rs`) or on understanding the existing `NodeExecutor` / `AgentState` model deeper than I can claim from a single-PR pass. They belong in follow-ups:

- `config.rs` — `GovernanceConfig` YAML loader (depends on `serde_yaml` dep + schema design)
- `guidance.rs` — `GuidanceContext` + Rule types (depends on this PR's parser API being stable)
- `nodes/governance.rs` — `GovernanceNode: NodeExecutor` (depends on understanding the node trait surface)
- `state.rs` extension — `guidance` + `agent_role` fields on `AgentState`

This PR is strictly additive and unblocks all of those.

## Verification (per AGENTS.md §1)

- `cargo build` — clean
- `cargo test --all-features --lib governance::` — **18/18 pass**
- `cargo test --all-features --test governance_types` — **6/6 pass**
- `cargo test --all-features --doc governance` — **1/1 pass** (doctest in `mod.rs`)
- **Total: 25/25 (18 unit + 6 integration + 1 doctest)**
- `rustfmt` clean on the 4 new files
- Pre-existing fmt/clippy noise visible on `develop` locally is toolchain drift between my macOS rustup and CI; not in scope.

Refs #31.