### PR TITLE
docs+test(governance): address self-CRR findings on #58 (F2-F5)

### DIFF
--- a/src/governance/parser.rs
+++ b/src/governance/parser.rs
@@ -19,7 +19,6 @@
 //! [`parse_blocks`] without re-implementing the scan.
 
 use crate::governance::roles::AgentRole;
-use std::str::FromStr;
 
 /// One contiguous region of a manifest scoped to a single role.
 ///
@@ -106,16 +105,19 @@ pub fn blocks_for<'a>(
 /// only), return the parsed role. A line like `prose <@builder> more
 /// prose` returns `None` — the tag must own the line to count as a
 /// block boundary, mirroring how `AGENTS.md` actually uses these.
+///
+/// Strict on the inner content: we strip the outer `<@`/`>` ourselves
+/// and feed the result to [`AgentRole::from_inner`] rather than the
+/// decoration-tolerant `FromStr`. This means a pathological input
+/// like `<@<@builder>>` produces `None` (the inner `<@builder>` is
+/// not a valid bare tag) instead of silently parsing as `Builder`.
 fn parse_tag_line(line: &str) -> Option<AgentRole> {
     let trimmed = line.trim();
     if !trimmed.starts_with("<@") || !trimmed.ends_with('>') {
         return None;
     }
-    // strip prefix/suffix and feed FromStr; FromStr re-handles the
-    // decoration but accepts the inner form directly too. Both error
-    // variants are equally "not a real boundary" — discard them.
     let inner = &trimmed[2..trimmed.len() - 1];
-    AgentRole::from_str(inner).ok()
+    AgentRole::from_inner(inner).ok()
 }
 
 #[cfg(test)]
@@ -254,5 +256,51 @@ mod tests {
         let blocks = parse_blocks(input);
         assert_eq!(blocks[0].tag_line, 1);
         assert_eq!(blocks[1].tag_line, 3);
+    }
+
+    /// Regression for the F5 finding on the WS1 follow-up CRR: `tag_line`
+    /// must stay accurate across many blocks with varying body lengths,
+    /// not just the trivial two-block case. Future `guidance.rs` slices
+    /// will surface diagnostics keyed on this value.
+    #[test]
+    fn tag_line_tracks_across_multi_block_input() {
+        let input = "\
+<@all>
+broadcast body 1
+broadcast body 2
+broadcast body 3
+<@architect>
+architect body
+<@builder>
+
+
+builder with leading blanks
+<@auditor>
+final block
+";
+        let blocks = parse_blocks(input);
+        assert_eq!(blocks.len(), 4);
+        let tag_lines: Vec<usize> = blocks.iter().map(|b| b.tag_line).collect();
+        // Lines: <@all>=1, body=2,3,4, <@architect>=5, body=6, <@builder>=7,
+        // blanks=8,9, body=10, <@auditor>=11, final=12.
+        assert_eq!(tag_lines, vec![1, 5, 7, 11]);
+    }
+
+    /// Regression for the F2 finding on the WS1 follow-up CRR: a
+    /// pathological double-wrapped tag like `<@<@builder>>` must NOT
+    /// silently parse as `Builder`. The strict `from_inner` path rejects
+    /// the inner `<@builder>` because it contains `<` / `>` characters
+    /// that aren't allowed in a bare tag body.
+    #[test]
+    fn nested_tag_decoration_is_not_a_boundary() {
+        let input = "<@builder>\nfirst\n<@<@builder>>\nsecond\n";
+        let blocks = parse_blocks(input);
+        // The malformed line is body, not a boundary — the single block
+        // stays open and absorbs both `first` and `second`.
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].role, AgentRole::Builder);
+        assert!(blocks[0].content.contains("first"));
+        assert!(blocks[0].content.contains("<@<@builder>>"));
+        assert!(blocks[0].content.contains("second"));
     }
 }

--- a/src/governance/roles.rs
+++ b/src/governance/roles.rs
@@ -22,6 +22,18 @@ use std::str::FromStr;
 /// `All` is the broadcast tag (`<@all>`). The four named variants are the
 /// canonical roles called out in issue #31; `Custom` carries any other
 /// tag (tool names, domain tags) verbatim so no information is lost.
+///
+/// # Note on `Auditor` / `Human`
+///
+/// The four canonical variants come from the issue #31 *spec*, not from
+/// the current `AGENTS.md`. The live manifest exercises `<@all>`,
+/// `<@architect>`, and `<@builder>` plus several tool/domain tags
+/// (`<@codex>`, `<@gemini>`, `<@sdlc>`, …); `Auditor` and `Human` are
+/// modelled here for forward use by `GovernanceNode` rule lookups, not
+/// because they appear in-tree today.
+///
+/// The `Hash` derive is intentional: a follow-up `guidance.rs` slice
+/// will use `AgentRole` as a key in rule / dispatch tables.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentRole {
@@ -85,31 +97,23 @@ pub enum RoleParseError {
     InvalidCharacter(String),
 }
 
-impl FromStr for AgentRole {
-    type Err = RoleParseError;
-
-    /// Parse a tag from its raw form — accepts the inner name (`builder`)
-    /// or the fully-tagged form (`<@builder>` / `@builder`), case
-    /// insensitively. Unknown but well-formed tags become
-    /// [`AgentRole::Custom`].
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+impl AgentRole {
+    /// Parse an *undecorated* tag body (e.g. `"builder"`, `"codex"`).
+    ///
+    /// This is the strict counterpart to [`FromStr::from_str`], which
+    /// accepts decorated forms (`<@builder>`, `@builder`). Use this when
+    /// the caller has already stripped decoration and would rather treat
+    /// any remaining `<@`/`@`/`>` characters as invalid input than have
+    /// them silently re-stripped. `parse_tag_line` in the sibling parser
+    /// module relies on this strictness — it lets a malformed input like
+    /// `<@<@builder>>` produce no boundary instead of silently parsing as
+    /// `Builder`.
+    pub fn from_inner(s: &str) -> Result<Self, RoleParseError> {
         let trimmed = s.trim();
         if trimmed.is_empty() {
             return Err(RoleParseError::Empty);
         }
-        // Strip optional `<@...>` or `@...` decoration so callers can pass
-        // either form. We only strip the outermost layer; nested angle
-        // brackets fall through to the InvalidCharacter check below.
-        let inner = trimmed
-            .strip_prefix("<@")
-            .and_then(|s| s.strip_suffix('>'))
-            .or_else(|| trimmed.strip_prefix('@'))
-            .unwrap_or(trimmed);
-
-        let lower = inner.to_ascii_lowercase();
-        if lower.is_empty() {
-            return Err(RoleParseError::Empty);
-        }
+        let lower = trimmed.to_ascii_lowercase();
         if !lower
             .chars()
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
@@ -125,6 +129,33 @@ impl FromStr for AgentRole {
             "human" => Self::Human,
             _ => Self::Custom(lower),
         })
+    }
+}
+
+impl FromStr for AgentRole {
+    type Err = RoleParseError;
+
+    /// Parse a tag from its raw form — accepts the inner name (`builder`)
+    /// or the fully-tagged form (`<@builder>` / `@builder`), case
+    /// insensitively. Unknown but well-formed tags become
+    /// [`AgentRole::Custom`]. Strict callers that have already stripped
+    /// decoration should prefer [`AgentRole::from_inner`] to avoid
+    /// double-stripping malformed inputs.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err(RoleParseError::Empty);
+        }
+        // Strip optional `<@...>` or `@...` decoration so callers can pass
+        // either form. Once the outermost layer is gone, defer to the
+        // strict `from_inner` so nested decoration doesn't get peeled
+        // a second time.
+        let inner = trimmed
+            .strip_prefix("<@")
+            .and_then(|s| s.strip_suffix('>'))
+            .or_else(|| trimmed.strip_prefix('@'))
+            .unwrap_or(trimmed);
+        Self::from_inner(inner)
     }
 }
 
@@ -232,5 +263,33 @@ mod tests {
         // `All` subscribers do NOT pick up concrete-role traffic — that
         // would defeat the point of role-scoped guidance.
         assert!(!AgentRole::All.receives(&AgentRole::Builder));
+    }
+
+    #[test]
+    fn from_inner_is_strict_about_decoration() {
+        // `from_inner` is the strict variant called from `parse_tag_line`
+        // after the outer `<@`/`>` has already been stripped. Any leftover
+        // decoration must be rejected — that's what prevents pathological
+        // inputs like `<@<@builder>>` from silently parsing as `Builder`.
+        assert!(AgentRole::from_inner("<@builder>").is_err());
+        assert!(AgentRole::from_inner("@builder").is_err());
+        // Bare names still work.
+        assert_eq!(
+            AgentRole::from_inner("builder").unwrap(),
+            AgentRole::Builder
+        );
+        assert_eq!(
+            AgentRole::from_inner("codex").unwrap(),
+            AgentRole::Custom("codex".into())
+        );
+        // Empty / whitespace-only still empty.
+        assert_eq!(
+            AgentRole::from_inner("").unwrap_err(),
+            RoleParseError::Empty
+        );
+        assert_eq!(
+            AgentRole::from_inner("   ").unwrap_err(),
+            RoleParseError::Empty
+        );
     }
 }


### PR DESCRIPTION
Follow-up to merged #58. Addresses [F2-F5 from the self-CRR](https://github.com/stevedores-org/oxidizedgraph/pull/58#pullrequestreview-4481330637) on that PR. F1 was a PR-body edit (test count); already in.

## Fixes

| # | Finding | Fix |
|---|---|---|
| **F2** | `parse_tag_line` redundantly re-stripped tag decoration via `FromStr`; pathological `<@<@builder>>` silently parsed as `Builder` | Split out `AgentRole::from_inner` as the strict variant — does not strip decoration, rejects any `<`/`>`/`@` characters in the body. `parse_tag_line` calls `from_inner` instead of `FromStr`. `FromStr` is unchanged externally and still calls `from_inner` after one outer strip. |
| **F3** | `Auditor` / `Human` come from issue #31's spec but don't appear in the live `AGENTS.md` | Added a `# Note on Auditor / Human` section to the `AgentRole` doc comment calling this out explicitly. |
| **F4** | `Hash` derive on `AgentRole` wasn't justified | Same doc-comment update notes the derive is intentional for the next `guidance.rs` slice's rule-lookup table. |
| **F5** | `tag_line` field only had one trivial test | New regression test `tag_line_tracks_across_multi_block_input` walks a 4-block manifest with varying body lengths and asserts exact line numbers (1, 5, 7, 11). |

## New tests

| Test | Where | Guards against |
|---|---|---|
| `from_inner_is_strict_about_decoration` | `roles.rs` | F2 — strict path rejects `<@builder>` / `@builder` as input |
| `nested_tag_decoration_is_not_a_boundary` | `parser.rs` | F2 — end-to-end: `<@<@builder>>` doesn't open a new block |
| `tag_line_tracks_across_multi_block_input` | `parser.rs` | F5 — `tag_line` stays faithful across multi-block input with varying body lengths |

## Verification

- `cargo build` — clean
- `cargo test --lib governance::` — **21/21** (was 18; +3)
- `cargo test --test governance_types` — **6/6**
- `cargo test --doc governance` — **1/1**
- **Total: 28/28**
- `rustfmt` clean

## Public API

No new public surface from the user's perspective. `AgentRole::from_inner` is added as a strict-path peer of the existing `FromStr` impl; the decoration-tolerant `from_str` is unchanged externally and now delegates to `from_inner` after one outer strip. Existing callers of `"<@builder>".parse::<AgentRole>()` keep working identically.

Refs #31. Follows merged #58.