### PR TITLE
feat(memory): decision-memory store for EPIC5 (issue #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Decision memory (`memory::decision`) — queryable log of *why* changes were
+  made, keyed by run and artifact. `DecisionStore` trait, in-memory backend,
+  and SurrealDB backend behind the `persistence` feature. First slice of
+  EPIC5 (issue #23).
 - Integration tests for complex graph patterns (`tests/graph_patterns.rs`)
   - Multi-branch conditional routing
   - Cycle with exit condition

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -815,3 +815,4 @@ mod tests {
         assert!(!packed.sections.is_empty());
     }
 }
+pub mod decision;

--- a/src/memory/decision/memory.rs
+++ b/src/memory/decision/memory.rs
@@ -1,0 +1,327 @@
+//! In-memory decision store for tests and single-process agents.
+//!
+//! Data is lost when the process exits — for durable storage, enable the
+//! `persistence` feature and use [`SurrealDecisionStore`].
+//!
+//! [`SurrealDecisionStore`]: super::SurrealDecisionStore
+
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use super::{Decision, DecisionStore};
+use crate::error::RuntimeError;
+
+fn poisoned<E: std::fmt::Display>(e: E) -> RuntimeError {
+    RuntimeError::InvalidState(format!("decision store lock poisoned: {}", e))
+}
+
+/// In-memory implementation of [`DecisionStore`].
+///
+/// Holds three indexes (by run, by change_ref, by tag) alongside the
+/// canonical id → decision map. Indexes are append-only on `record` and
+/// pruned on `delete`. Listings are sorted newest-first at read time.
+pub struct MemoryDecisionStore {
+    by_id: RwLock<HashMap<String, Decision>>,
+    by_run: RwLock<HashMap<String, Vec<String>>>,
+    by_change: RwLock<HashMap<String, Vec<String>>>,
+    by_tag: RwLock<HashMap<String, Vec<String>>>,
+}
+
+impl MemoryDecisionStore {
+    /// Create an empty in-memory store.
+    pub fn new() -> Self {
+        Self {
+            by_id: RwLock::new(HashMap::new()),
+            by_run: RwLock::new(HashMap::new()),
+            by_change: RwLock::new(HashMap::new()),
+            by_tag: RwLock::new(HashMap::new()),
+        }
+    }
+
+    fn sorted_newest_first(&self, ids: &[String]) -> Result<Vec<Decision>, RuntimeError> {
+        let by_id = self.by_id.read().map_err(poisoned)?;
+        let mut out: Vec<Decision> = ids.iter().filter_map(|id| by_id.get(id).cloned()).collect();
+        out.sort_by_key(|d| std::cmp::Reverse(d.created_at));
+        Ok(out)
+    }
+}
+
+impl Default for MemoryDecisionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl DecisionStore for MemoryDecisionStore {
+    async fn record(&self, decision: Decision) -> Result<(), RuntimeError> {
+        let id = decision.id.clone();
+        let run_id = decision.run_id.clone();
+        let change_ref = decision.change_ref.clone();
+        let tags = decision.tags.clone();
+
+        let prev = {
+            let mut by_id = self.by_id.write().map_err(poisoned)?;
+            by_id.insert(id.clone(), decision)
+        };
+
+        // If we're overwriting, drop the prior index entries first so
+        // run/change/tag lookups don't return stale duplicates.
+        if let Some(prev) = prev {
+            self.remove_from_indexes(&prev)?;
+        }
+
+        {
+            let mut by_run = self.by_run.write().map_err(poisoned)?;
+            by_run.entry(run_id).or_default().push(id.clone());
+        }
+        {
+            let mut by_change = self.by_change.write().map_err(poisoned)?;
+            by_change.entry(change_ref).or_default().push(id.clone());
+        }
+        {
+            let mut by_tag = self.by_tag.write().map_err(poisoned)?;
+            for tag in tags {
+                by_tag.entry(tag).or_default().push(id.clone());
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn get(&self, id: &str) -> Result<Option<Decision>, RuntimeError> {
+        let by_id = self.by_id.read().map_err(poisoned)?;
+        Ok(by_id.get(id).cloned())
+    }
+
+    async fn list_by_run(&self, run_id: &str) -> Result<Vec<Decision>, RuntimeError> {
+        let ids = {
+            let by_run = self.by_run.read().map_err(poisoned)?;
+            by_run.get(run_id).cloned().unwrap_or_default()
+        };
+        self.sorted_newest_first(&ids)
+    }
+
+    async fn list_by_change(&self, change_ref: &str) -> Result<Vec<Decision>, RuntimeError> {
+        let ids = {
+            let by_change = self.by_change.read().map_err(poisoned)?;
+            by_change.get(change_ref).cloned().unwrap_or_default()
+        };
+        self.sorted_newest_first(&ids)
+    }
+
+    async fn list_by_tag(&self, tag: &str) -> Result<Vec<Decision>, RuntimeError> {
+        let ids = {
+            let by_tag = self.by_tag.read().map_err(poisoned)?;
+            by_tag.get(tag).cloned().unwrap_or_default()
+        };
+        self.sorted_newest_first(&ids)
+    }
+
+    async fn recent(&self, limit: usize) -> Result<Vec<Decision>, RuntimeError> {
+        let mut all: Vec<Decision> = {
+            let by_id = self.by_id.read().map_err(poisoned)?;
+            by_id.values().cloned().collect()
+        };
+        all.sort_by_key(|d| std::cmp::Reverse(d.created_at));
+        all.truncate(limit);
+        Ok(all)
+    }
+
+    async fn delete(&self, id: &str) -> Result<(), RuntimeError> {
+        let removed = {
+            let mut by_id = self.by_id.write().map_err(poisoned)?;
+            by_id.remove(id)
+        };
+        if let Some(d) = removed {
+            self.remove_from_indexes(&d)?;
+        }
+        Ok(())
+    }
+}
+
+impl MemoryDecisionStore {
+    fn remove_from_indexes(&self, d: &Decision) -> Result<(), RuntimeError> {
+        {
+            let mut by_run = self.by_run.write().map_err(poisoned)?;
+            if let Some(ids) = by_run.get_mut(&d.run_id) {
+                ids.retain(|x| x != &d.id);
+            }
+        }
+        {
+            let mut by_change = self.by_change.write().map_err(poisoned)?;
+            if let Some(ids) = by_change.get_mut(&d.change_ref) {
+                ids.retain(|x| x != &d.id);
+            }
+        }
+        {
+            let mut by_tag = self.by_tag.write().map_err(poisoned)?;
+            for tag in &d.tags {
+                if let Some(ids) = by_tag.get_mut(tag) {
+                    ids.retain(|x| x != &d.id);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+
+    fn d(run: &str, change: &str, title: &str) -> Decision {
+        Decision::new(run, change, title, "rationale")
+    }
+
+    #[tokio::test]
+    async fn record_and_get_round_trip() {
+        let store = MemoryDecisionStore::new();
+        let decision = d("run-1", "src/a.rs", "swap lock").with_tag("perf");
+        let id = decision.id.clone();
+        store.record(decision).await.unwrap();
+
+        let got = store.get(&id).await.unwrap().expect("present");
+        assert_eq!(got.title, "swap lock");
+        assert_eq!(got.tags, vec!["perf"]);
+    }
+
+    #[tokio::test]
+    async fn get_missing_returns_none() {
+        let store = MemoryDecisionStore::new();
+        assert!(store.get("does-not-exist").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn list_by_run_returns_newest_first() {
+        let store = MemoryDecisionStore::new();
+        let mut older = d("run-1", "a", "older");
+        let newer = d("run-1", "b", "newer");
+        // Force a deterministic ordering — `Utc::now()` resolution can
+        // collide inside a single test on fast machines.
+        older.created_at = newer.created_at - Duration::seconds(10);
+        store.record(older).await.unwrap();
+        store.record(newer).await.unwrap();
+
+        let listed = store.list_by_run("run-1").await.unwrap();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0].title, "newer");
+        assert_eq!(listed[1].title, "older");
+    }
+
+    #[tokio::test]
+    async fn list_by_change_isolates_artifacts() {
+        let store = MemoryDecisionStore::new();
+        store.record(d("run-1", "src/a.rs", "a1")).await.unwrap();
+        store.record(d("run-1", "src/b.rs", "b1")).await.unwrap();
+        store.record(d("run-2", "src/a.rs", "a2")).await.unwrap();
+
+        let a = store.list_by_change("src/a.rs").await.unwrap();
+        assert_eq!(a.len(), 2);
+        assert!(a.iter().all(|d| d.change_ref == "src/a.rs"));
+
+        let b = store.list_by_change("src/b.rs").await.unwrap();
+        assert_eq!(b.len(), 1);
+        assert_eq!(b[0].title, "b1");
+
+        assert!(store.list_by_change("src/c.rs").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_by_tag_groups_across_runs_and_changes() {
+        let store = MemoryDecisionStore::new();
+        store
+            .record(d("run-1", "src/a.rs", "perf change").with_tag("perf"))
+            .await
+            .unwrap();
+        store
+            .record(
+                d("run-2", "src/b.rs", "perf + sec change")
+                    .with_tag("perf")
+                    .with_tag("security"),
+            )
+            .await
+            .unwrap();
+        store
+            .record(d("run-3", "src/c.rs", "doc only").with_tag("docs"))
+            .await
+            .unwrap();
+
+        let perf = store.list_by_tag("perf").await.unwrap();
+        assert_eq!(perf.len(), 2);
+
+        let sec = store.list_by_tag("security").await.unwrap();
+        assert_eq!(sec.len(), 1);
+
+        assert!(store.list_by_tag("nope").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn recent_truncates_and_orders() {
+        let store = MemoryDecisionStore::new();
+        let now = Utc::now();
+        for i in 0..5 {
+            let mut decision = d("run-1", &format!("change-{i}"), &format!("t{i}"));
+            decision.created_at = now + Duration::seconds(i);
+            store.record(decision).await.unwrap();
+        }
+
+        let top3 = store.recent(3).await.unwrap();
+        assert_eq!(top3.len(), 3);
+        assert_eq!(top3[0].title, "t4");
+        assert_eq!(top3[1].title, "t3");
+        assert_eq!(top3[2].title, "t2");
+    }
+
+    #[tokio::test]
+    async fn delete_removes_from_all_indexes() {
+        let store = MemoryDecisionStore::new();
+        let decision = d("run-1", "src/a.rs", "t").with_tag("perf");
+        let id = decision.id.clone();
+        store.record(decision).await.unwrap();
+        store.delete(&id).await.unwrap();
+
+        assert!(store.get(&id).await.unwrap().is_none());
+        assert!(store.list_by_run("run-1").await.unwrap().is_empty());
+        assert!(store.list_by_change("src/a.rs").await.unwrap().is_empty());
+        assert!(store.list_by_tag("perf").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_missing_is_noop() {
+        let store = MemoryDecisionStore::new();
+        store.delete("never-recorded").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn record_overwrites_and_reindexes() {
+        let store = MemoryDecisionStore::new();
+        let original = d("run-1", "src/a.rs", "v1").with_tag("perf");
+        let id = original.id.clone();
+        store.record(original).await.unwrap();
+
+        // Re-record under the same id but with different run/change/tags.
+        let updated = Decision {
+            id: id.clone(),
+            run_id: "run-2".into(),
+            change_ref: "src/b.rs".into(),
+            title: "v2".into(),
+            rationale: "different".into(),
+            tags: vec!["security".into()],
+            created_at: Utc::now(),
+            metadata: serde_json::Value::Null,
+        };
+        store.record(updated).await.unwrap();
+
+        // Old indexes must be empty; new indexes must contain it once.
+        assert!(store.list_by_run("run-1").await.unwrap().is_empty());
+        assert!(store.list_by_change("src/a.rs").await.unwrap().is_empty());
+        assert!(store.list_by_tag("perf").await.unwrap().is_empty());
+
+        assert_eq!(store.list_by_run("run-2").await.unwrap().len(), 1);
+        assert_eq!(store.list_by_change("src/b.rs").await.unwrap().len(), 1);
+        assert_eq!(store.list_by_tag("security").await.unwrap().len(), 1);
+    }
+}

--- a/src/memory/decision/mod.rs
+++ b/src/memory/decision/mod.rs
@@ -1,0 +1,196 @@
+//! Decision memory: a queryable log of *why* changes were made.
+//!
+//! Each [`Decision`] records the rationale behind a non-trivial change an
+//! agent run produced, tied to the artifact that change touched
+//! (`change_ref` — typically a commit SHA, PR number, file path, or node
+//! id). Decisions are grouped by `run_id` and tagged for cross-cutting
+//! queries.
+//!
+//! Implementations:
+//!
+//! - [`MemoryDecisionStore`] — in-memory, always available. Suitable for
+//!   tests and single-process agents.
+//! - [`SurrealDecisionStore`] — SurrealDB-backed, gated by the
+//!   `persistence` feature. Suitable for production swarms.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use oxidizedgraph::memory::decision::{Decision, DecisionStore, MemoryDecisionStore};
+//!
+//! let store = MemoryDecisionStore::new();
+//!
+//! let decision = Decision::new(
+//!     "run-42",
+//!     "src/runner.rs",
+//!     "Swap RwLock for parking_lot",
+//!     "std RwLock can poison on panic; parking_lot avoids the recovery dance.",
+//! )
+//! .with_tag("perf")
+//! .with_tag("locking");
+//!
+//! store.record(decision).await?;
+//!
+//! let by_run = store.list_by_run("run-42").await?;
+//! assert_eq!(by_run.len(), 1);
+//! # Ok::<(), oxidizedgraph::error::RuntimeError>(())
+//! ```
+
+mod memory;
+#[cfg(feature = "persistence")]
+mod surreal;
+
+pub use memory::MemoryDecisionStore;
+#[cfg(feature = "persistence")]
+pub use surreal::SurrealDecisionStore;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::RuntimeError;
+
+/// A single architectural or behavioral decision an agent run produced.
+///
+/// `change_ref` is intentionally a free-form string so callers can point at
+/// whatever level of granularity makes sense (commit SHA, PR number, file
+/// path, graph node id, ADR slug). Consumers that need a typed reference
+/// should layer their own scheme on top of `change_ref` + `metadata`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Decision {
+    /// Unique identifier for this decision record.
+    pub id: String,
+
+    /// The agent run that produced this decision.
+    pub run_id: String,
+
+    /// The artifact this decision refers to (commit, PR, file, node id…).
+    pub change_ref: String,
+
+    /// Short, one-line summary of the decision.
+    pub title: String,
+
+    /// The "why" — full rationale. May be multi-paragraph markdown.
+    pub rationale: String,
+
+    /// Tags for cross-cutting queries (e.g. `"perf"`, `"security"`).
+    #[serde(default)]
+    pub tags: Vec<String>,
+
+    /// When this decision was recorded.
+    pub created_at: DateTime<Utc>,
+
+    /// Free-form structured metadata (caller-defined schema).
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+}
+
+impl Decision {
+    /// Create a new decision with a generated id and `created_at = now`.
+    pub fn new(
+        run_id: impl Into<String>,
+        change_ref: impl Into<String>,
+        title: impl Into<String>,
+        rationale: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            run_id: run_id.into(),
+            change_ref: change_ref.into(),
+            title: title.into(),
+            rationale: rationale.into(),
+            tags: Vec::new(),
+            created_at: Utc::now(),
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    /// Attach a tag (chainable).
+    pub fn with_tag(mut self, tag: impl Into<String>) -> Self {
+        self.tags.push(tag.into());
+        self
+    }
+
+    /// Replace tags (chainable).
+    pub fn with_tags<I, S>(mut self, tags: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.tags = tags.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Attach structured metadata (chainable).
+    pub fn with_metadata(mut self, metadata: serde_json::Value) -> Self {
+        self.metadata = metadata;
+        self
+    }
+}
+
+/// Storage backend for decision memory.
+///
+/// Implementations must be `Send + Sync` so they can be shared across
+/// tokio tasks. All listing methods return results **newest first** —
+/// callers typically want the most recent rationale for an artifact.
+#[async_trait]
+pub trait DecisionStore: Send + Sync {
+    /// Persist a decision. Overwrites any existing record with the same id.
+    async fn record(&self, decision: Decision) -> Result<(), RuntimeError>;
+
+    /// Fetch a decision by its id.
+    async fn get(&self, id: &str) -> Result<Option<Decision>, RuntimeError>;
+
+    /// Decisions produced by a specific run, newest first.
+    async fn list_by_run(&self, run_id: &str) -> Result<Vec<Decision>, RuntimeError>;
+
+    /// Decisions touching a specific artifact, newest first.
+    ///
+    /// Used to answer "why does this file/node/commit look the way it does?"
+    async fn list_by_change(&self, change_ref: &str) -> Result<Vec<Decision>, RuntimeError>;
+
+    /// Decisions tagged with `tag`, newest first.
+    async fn list_by_tag(&self, tag: &str) -> Result<Vec<Decision>, RuntimeError>;
+
+    /// Most recent decisions across all runs, capped at `limit`.
+    async fn recent(&self, limit: usize) -> Result<Vec<Decision>, RuntimeError>;
+
+    /// Delete a decision by id. No-op if it does not exist.
+    async fn delete(&self, id: &str) -> Result<(), RuntimeError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decision_new_populates_fields() {
+        let d = Decision::new("run-1", "src/foo.rs", "title", "rationale");
+        assert!(!d.id.is_empty());
+        assert_eq!(d.run_id, "run-1");
+        assert_eq!(d.change_ref, "src/foo.rs");
+        assert_eq!(d.title, "title");
+        assert_eq!(d.rationale, "rationale");
+        assert!(d.tags.is_empty());
+        assert!(d.metadata.is_null());
+    }
+
+    #[test]
+    fn decision_builders_chain() {
+        let d = Decision::new("run-1", "PR#9", "t", "r")
+            .with_tag("perf")
+            .with_tag("locking")
+            .with_metadata(serde_json::json!({ "owner": "alice" }));
+        assert_eq!(d.tags, vec!["perf", "locking"]);
+        assert_eq!(d.metadata["owner"], "alice");
+    }
+
+    #[test]
+    fn decision_with_tags_replaces() {
+        let d = Decision::new("run-1", "x", "t", "r")
+            .with_tag("a")
+            .with_tags(["b", "c"]);
+        assert_eq!(d.tags, vec!["b", "c"]);
+    }
+}

--- a/src/memory/decision/surreal.rs
+++ b/src/memory/decision/surreal.rs
@@ -1,0 +1,404 @@
+//! SurrealDB-backed decision store for production agents.
+//!
+//! Gated by the `persistence` feature, mirroring [`SurrealCheckpointer`].
+//!
+//! ```toml
+//! oxidizedgraph = { version = "0.2", features = ["persistence"] }
+//! ```
+//!
+//! [`SurrealCheckpointer`]: crate::checkpoint::SurrealCheckpointer
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use surrealdb::engine::any::{connect, Any};
+use surrealdb::opt::auth::Root;
+use surrealdb::sql::Thing;
+use surrealdb::Surreal;
+
+use super::{Decision, DecisionStore};
+use crate::error::RuntimeError;
+
+const TABLE: &str = "decisions";
+
+/// SurrealDB-backed implementation of [`DecisionStore`].
+///
+/// Supports the same connection modes as the existing
+/// [`SurrealCheckpointer`]:
+///
+/// - In-memory: [`SurrealDecisionStore::memory`]
+/// - File-based: [`SurrealDecisionStore::file`]
+/// - Remote: [`SurrealDecisionStore::connect_remote`]
+///
+/// [`SurrealCheckpointer`]: crate::checkpoint::SurrealCheckpointer
+pub struct SurrealDecisionStore {
+    db: Surreal<Any>,
+}
+
+/// Builder for connecting [`SurrealDecisionStore`] to a remote SurrealDB.
+pub struct SurrealDecisionStoreBuilder {
+    url: String,
+    username: Option<String>,
+    password: Option<String>,
+    namespace: String,
+    database: String,
+}
+
+impl SurrealDecisionStoreBuilder {
+    /// Set authentication credentials.
+    pub fn credentials(mut self, username: impl Into<String>, password: impl Into<String>) -> Self {
+        self.username = Some(username.into());
+        self.password = Some(password.into());
+        self
+    }
+
+    /// Set the namespace.
+    pub fn namespace(mut self, ns: impl Into<String>) -> Self {
+        self.namespace = ns.into();
+        self
+    }
+
+    /// Set the database.
+    pub fn database(mut self, db: impl Into<String>) -> Self {
+        self.database = db.into();
+        self
+    }
+
+    /// Connect, sign in, and select ns/db.
+    pub async fn build(self) -> Result<SurrealDecisionStore, RuntimeError> {
+        let db: Surreal<Any> = connect(&self.url)
+            .await
+            .map_err(|e| RuntimeError::InvalidState(format!("SurrealDB connect failed: {}", e)))?;
+
+        if let (Some(user), Some(pass)) = (self.username, self.password) {
+            db.signin(Root {
+                username: &user,
+                password: &pass,
+            })
+            .await
+            .map_err(|e| RuntimeError::InvalidState(format!("SurrealDB auth failed: {}", e)))?;
+        }
+
+        db.use_ns(&self.namespace)
+            .use_db(&self.database)
+            .await
+            .map_err(|e| {
+                RuntimeError::InvalidState(format!("SurrealDB use ns/db failed: {}", e))
+            })?;
+
+        let store = SurrealDecisionStore { db };
+        store.setup_schema().await?;
+        Ok(store)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct DecisionRecord {
+    #[allow(dead_code)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<Thing>,
+    decision_id: String,
+    run_id: String,
+    change_ref: String,
+    title: String,
+    rationale: String,
+    #[serde(default)]
+    tags: Vec<String>,
+    created_at: String,
+    #[serde(default)]
+    metadata: serde_json::Value,
+}
+
+impl From<Decision> for DecisionRecord {
+    fn from(d: Decision) -> Self {
+        Self {
+            id: None,
+            decision_id: d.id,
+            run_id: d.run_id,
+            change_ref: d.change_ref,
+            title: d.title,
+            rationale: d.rationale,
+            tags: d.tags,
+            created_at: d.created_at.to_rfc3339(),
+            metadata: if d.metadata.is_null() {
+                serde_json::json!({})
+            } else {
+                d.metadata
+            },
+        }
+    }
+}
+
+impl TryFrom<DecisionRecord> for Decision {
+    type Error = RuntimeError;
+
+    fn try_from(r: DecisionRecord) -> Result<Self, Self::Error> {
+        let created_at = chrono::DateTime::parse_from_rfc3339(&r.created_at)
+            .map_err(|e| RuntimeError::InvalidState(format!("Failed to parse timestamp: {}", e)))?
+            .with_timezone(&chrono::Utc);
+
+        Ok(Decision {
+            id: r.decision_id,
+            run_id: r.run_id,
+            change_ref: r.change_ref,
+            title: r.title,
+            rationale: r.rationale,
+            tags: r.tags,
+            created_at,
+            metadata: r.metadata,
+        })
+    }
+}
+
+impl SurrealDecisionStore {
+    /// In-memory backend, for tests.
+    pub async fn memory() -> Result<Self, RuntimeError> {
+        Self::open("mem://").await
+    }
+
+    /// File-backed embedded store.
+    pub async fn file(path: impl AsRef<str>) -> Result<Self, RuntimeError> {
+        let url = format!("file://{}", path.as_ref());
+        Self::open(&url).await
+    }
+
+    /// Start a builder for a remote SurrealDB connection.
+    pub fn connect_remote(url: impl Into<String>) -> SurrealDecisionStoreBuilder {
+        SurrealDecisionStoreBuilder {
+            url: url.into(),
+            username: None,
+            password: None,
+            namespace: "oxidizedgraph".to_string(),
+            database: "decisions".to_string(),
+        }
+    }
+
+    async fn open(url: &str) -> Result<Self, RuntimeError> {
+        let db: Surreal<Any> = connect(url)
+            .await
+            .map_err(|e| RuntimeError::InvalidState(format!("SurrealDB connect failed: {}", e)))?;
+
+        db.use_ns("oxidizedgraph")
+            .use_db("decisions")
+            .await
+            .map_err(|e| {
+                RuntimeError::InvalidState(format!("SurrealDB use ns/db failed: {}", e))
+            })?;
+
+        let store = Self { db };
+        store.setup_schema().await?;
+        Ok(store)
+    }
+
+    async fn setup_schema(&self) -> Result<(), RuntimeError> {
+        self.db
+            .query(
+                r#"
+                DEFINE INDEX IF NOT EXISTS idx_run_id ON TABLE decisions COLUMNS run_id;
+                DEFINE INDEX IF NOT EXISTS idx_change_ref ON TABLE decisions COLUMNS change_ref;
+                DEFINE INDEX IF NOT EXISTS idx_tags ON TABLE decisions COLUMNS tags;
+                DEFINE INDEX IF NOT EXISTS idx_created_at ON TABLE decisions COLUMNS created_at;
+                "#,
+            )
+            .await
+            .map_err(|e| RuntimeError::InvalidState(format!("Failed to setup schema: {}", e)))?;
+        Ok(())
+    }
+
+    async fn query_records(
+        &self,
+        sql: &'static str,
+        bindings: Vec<(&'static str, String)>,
+    ) -> Result<Vec<DecisionRecord>, RuntimeError> {
+        let mut q = self.db.query(sql);
+        for (k, v) in bindings {
+            q = q.bind((k, v));
+        }
+        let mut result = q
+            .await
+            .map_err(|e| RuntimeError::InvalidState(format!("SurrealDB query failed: {}", e)))?;
+        result
+            .take(0)
+            .map_err(|e| RuntimeError::InvalidState(format!("Failed to parse result: {}", e)))
+    }
+}
+
+#[async_trait]
+impl DecisionStore for SurrealDecisionStore {
+    async fn record(&self, decision: Decision) -> Result<(), RuntimeError> {
+        let record: DecisionRecord = decision.into();
+        let id = record.decision_id.clone();
+
+        // upsert: a re-`record` of the same id must overwrite, matching the
+        // in-memory backend's contract.
+        let _: Option<DecisionRecord> = self
+            .db
+            .upsert((TABLE, id))
+            .content(record)
+            .await
+            .map_err(|e| RuntimeError::InvalidState(format!("Failed to record decision: {}", e)))?;
+        Ok(())
+    }
+
+    async fn get(&self, id: &str) -> Result<Option<Decision>, RuntimeError> {
+        let record: Option<DecisionRecord> =
+            self.db.select((TABLE, id)).await.map_err(|e| {
+                RuntimeError::InvalidState(format!("Failed to load decision: {}", e))
+            })?;
+        match record {
+            Some(r) => Ok(Some(r.try_into()?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn list_by_run(&self, run_id: &str) -> Result<Vec<Decision>, RuntimeError> {
+        let records = self
+            .query_records(
+                "SELECT * FROM decisions WHERE run_id = $run_id ORDER BY created_at DESC",
+                vec![("run_id", run_id.to_string())],
+            )
+            .await?;
+        records.into_iter().map(|r| r.try_into()).collect()
+    }
+
+    async fn list_by_change(&self, change_ref: &str) -> Result<Vec<Decision>, RuntimeError> {
+        let records = self
+            .query_records(
+                "SELECT * FROM decisions WHERE change_ref = $change_ref ORDER BY created_at DESC",
+                vec![("change_ref", change_ref.to_string())],
+            )
+            .await?;
+        records.into_iter().map(|r| r.try_into()).collect()
+    }
+
+    async fn list_by_tag(&self, tag: &str) -> Result<Vec<Decision>, RuntimeError> {
+        let records = self
+            .query_records(
+                "SELECT * FROM decisions WHERE $tag IN tags ORDER BY created_at DESC",
+                vec![("tag", tag.to_string())],
+            )
+            .await?;
+        records.into_iter().map(|r| r.try_into()).collect()
+    }
+
+    async fn recent(&self, limit: usize) -> Result<Vec<Decision>, RuntimeError> {
+        let mut result = self
+            .db
+            .query("SELECT * FROM decisions ORDER BY created_at DESC LIMIT $limit")
+            .bind(("limit", limit as i64))
+            .await
+            .map_err(|e| RuntimeError::InvalidState(format!("SurrealDB query failed: {}", e)))?;
+        let records: Vec<DecisionRecord> = result
+            .take(0)
+            .map_err(|e| RuntimeError::InvalidState(format!("Failed to parse result: {}", e)))?;
+        records.into_iter().map(|r| r.try_into()).collect()
+    }
+
+    async fn delete(&self, id: &str) -> Result<(), RuntimeError> {
+        let _: Option<DecisionRecord> =
+            self.db.delete((TABLE, id)).await.map_err(|e| {
+                RuntimeError::InvalidState(format!("Failed to delete decision: {}", e))
+            })?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn d(run: &str, change: &str, title: &str) -> Decision {
+        Decision::new(run, change, title, "rationale")
+    }
+
+    #[tokio::test]
+    async fn round_trip_through_memory_backend() {
+        let store = SurrealDecisionStore::memory().await.unwrap();
+        let decision = d("run-1", "src/a.rs", "swap lock").with_tag("perf");
+        let id = decision.id.clone();
+        store.record(decision).await.unwrap();
+
+        let got = store.get(&id).await.unwrap().expect("present");
+        assert_eq!(got.title, "swap lock");
+        assert_eq!(got.tags, vec!["perf".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn list_by_run_orders_newest_first() {
+        let store = SurrealDecisionStore::memory().await.unwrap();
+        store.record(d("run-1", "a", "first")).await.unwrap();
+        // Sleep briefly so created_at differs at rfc3339 resolution.
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        store.record(d("run-1", "b", "second")).await.unwrap();
+
+        let listed = store.list_by_run("run-1").await.unwrap();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0].title, "second");
+    }
+
+    #[tokio::test]
+    async fn list_by_change_and_tag() {
+        let store = SurrealDecisionStore::memory().await.unwrap();
+        store
+            .record(d("run-1", "src/a.rs", "a1").with_tag("perf"))
+            .await
+            .unwrap();
+        store
+            .record(d("run-1", "src/b.rs", "b1").with_tag("security"))
+            .await
+            .unwrap();
+        store
+            .record(d("run-2", "src/a.rs", "a2").with_tag("perf"))
+            .await
+            .unwrap();
+
+        let by_change = store.list_by_change("src/a.rs").await.unwrap();
+        assert_eq!(by_change.len(), 2);
+
+        let by_tag = store.list_by_tag("perf").await.unwrap();
+        assert_eq!(by_tag.len(), 2);
+
+        assert!(store.list_by_tag("nope").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn recent_respects_limit() {
+        let store = SurrealDecisionStore::memory().await.unwrap();
+        for i in 0..5 {
+            store
+                .record(d("run-1", &format!("c{i}"), &format!("t{i}")))
+                .await
+                .unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+        let top = store.recent(3).await.unwrap();
+        assert_eq!(top.len(), 3);
+        // Newest first.
+        assert_eq!(top[0].title, "t4");
+    }
+
+    #[tokio::test]
+    async fn delete_round_trips() {
+        let store = SurrealDecisionStore::memory().await.unwrap();
+        let decision = d("run-1", "src/a.rs", "x");
+        let id = decision.id.clone();
+        store.record(decision).await.unwrap();
+        store.delete(&id).await.unwrap();
+        assert!(store.get(&id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn record_overwrites_same_id() {
+        let store = SurrealDecisionStore::memory().await.unwrap();
+        let mut decision = d("run-1", "src/a.rs", "v1");
+        let id = decision.id.clone();
+        store.record(decision.clone()).await.unwrap();
+
+        decision.title = "v2".into();
+        store.record(decision).await.unwrap();
+
+        let got = store.get(&id).await.unwrap().expect("present");
+        assert_eq!(got.title, "v2");
+        // Still only one record overall.
+        assert_eq!(store.list_by_run("run-1").await.unwrap().len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

First slice of **EPIC5 — Memory, Context, and Retrieval** (#23). Lands a queryable log of the *why* behind agent-produced changes, mapping directly to the acceptance criterion **"Decision rationale is queryable for each major change."**

- New module `memory::decision` mirroring the existing `checkpoint::` pattern.
- `Decision` record + `DecisionStore` trait with `record` / `get` / `list_by_run` / `list_by_change` / `list_by_tag` / `recent` / `delete`. All list methods are newest-first.
- `MemoryDecisionStore` always available; `SurrealDecisionStore` gated by the existing `persistence` feature (no new deps).

## Scope

This PR delivers **one of four** EPIC5 sub-features. The remaining three — repository indexing, episodic memory, and context-packing policy — should land as separate follow-up PRs against the same epic. Splitting reduces blast radius and lets reviewers focus on a single, self-contained surface.

## Test plan

- [x] `cargo test --lib memory::` — 11 in-memory tests pass
- [x] `cargo test --lib --all-features memory::` — 17 tests pass (adds the 6 SurrealDB tests on `mem://`)
- [x] `cargo test --all-features` — full suite, 205 tests, no regressions
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean for the new module (two `large_enum_variant` errors in `src/checkpoint/runner.rs` and `src/events/runner.rs` pre-exist on `develop` and are out of scope here)
- [x] `cargo fmt --check` — clean for the new files
- [ ] Reviewer: confirm the trait shape is the one we want before episodic / indexing layers start building on top of it
- [ ] Reviewer: verify SurrealDB index definitions in `setup_schema` match house style

## Acceptance criteria touched

> Decision rationale is queryable for each major change

Covered by `DecisionStore::list_by_change(change_ref)` — see the `list_by_change_isolates_artifacts` test for the round-trip.

Closes part of #23 (decision-memory sub-feature only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)