### PR TITLE
feat: add perf benches and real server execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +603,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +750,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +821,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -2003,6 +2076,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,6 +2666,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,6 +2723,7 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
+ "criterion",
  "crossbeam-channel",
  "derive_builder",
  "futures",
@@ -2842,6 +2933,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polling"
@@ -4420,6 +4539,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ surrealdb = { version = "2", optional = true, features = ["kv-mem"] }
 [dev-dependencies]
 tokio-test = "0.4"
 mockall = "0.13"
+criterion = "0.5"
 
 [[example]]
 name = "simple_workflow"
@@ -96,3 +97,7 @@ path = "examples/enterprise_workflow.rs"
 [[bin]]
 name = "oxidizedgraph-server"
 path = "src/bin/server.rs"
+
+[[bench]]
+name = "perf"
+harness = false

--- a/benches/perf.rs
+++ b/benches/perf.rs
@@ -95,7 +95,7 @@ fn benchmark_checkpoint_save(c: &mut Criterion) {
 
     c.bench_function("checkpoint_save", |b| {
         b.iter_batched(
-            || MemoryCheckpointer::new(),
+            MemoryCheckpointer::new,
             |checkpointer| {
                 runtime.block_on(async {
                     checkpointer

--- a/benches/perf.rs
+++ b/benches/perf.rs
@@ -1,0 +1,215 @@
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use oxidizedgraph::prelude::*;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+struct RouteNode {
+    id: String,
+    transition: String,
+}
+
+#[async_trait]
+impl NodeExecutor for RouteNode {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn execute(&self, _state: SharedState) -> Result<NodeOutput, NodeError> {
+        Ok(NodeOutput::transition(self.transition.clone()))
+    }
+}
+
+struct FinishNode {
+    id: String,
+}
+
+#[async_trait]
+impl NodeExecutor for FinishNode {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn execute(&self, _state: SharedState) -> Result<NodeOutput, NodeError> {
+        Ok(NodeOutput::finish())
+    }
+}
+
+fn build_compile_graph(width: usize) -> GraphBuilder {
+    let mut builder = GraphBuilder::new()
+        .name("perf-graph")
+        .set_entry_point("router");
+
+    builder = builder.add_node(RouteNode {
+        id: "router".to_string(),
+        transition: "route-0".to_string(),
+    });
+
+    for idx in 0..width {
+        let node_id = format!("node-{idx}");
+        builder = builder.add_node(FinishNode {
+            id: node_id.clone(),
+        });
+        builder = builder.add_edge_with_key("router", node_id, format!("route-{idx}"));
+    }
+
+    builder
+}
+
+fn build_invoke_graph(width: usize) -> CompiledGraph {
+    build_compile_graph(width).compile().unwrap()
+}
+
+fn benchmark_graph_compile(c: &mut Criterion) {
+    c.bench_function("graph_compile_128_edges", |b| {
+        b.iter(|| {
+            let graph = black_box(build_compile_graph(128));
+            black_box(graph.compile().unwrap())
+        })
+    });
+}
+
+fn benchmark_graph_invoke(c: &mut Criterion) {
+    let runtime = Runtime::new().unwrap();
+    let graph = build_invoke_graph(128);
+    let runner = GraphRunner::with_defaults(graph);
+    let state = {
+        let mut state = AgentState::new();
+        state.set_context("route", "route-127");
+        state
+    };
+
+    c.bench_function("graph_invoke_128_routes", |b| {
+        b.iter(|| {
+            runtime.block_on(async {
+                let result = runner.invoke(black_box(state.clone())).await.unwrap();
+                black_box(result)
+            })
+        })
+    });
+}
+
+fn benchmark_checkpoint_save(c: &mut Criterion) {
+    let runtime = Runtime::new().unwrap();
+    let state = AgentState::with_user_message("benchmark checkpointing");
+    let checkpoint = Checkpoint::new("thread-bench", "node-a", state);
+
+    c.bench_function("checkpoint_save", |b| {
+        b.iter_batched(
+            || MemoryCheckpointer::new(),
+            |checkpointer| {
+                runtime.block_on(async {
+                    checkpointer
+                        .save(black_box(checkpoint.clone()))
+                        .await
+                        .unwrap();
+                });
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    let populated = runtime.block_on(async {
+        let checkpointer = MemoryCheckpointer::new();
+        for idx in 0..32 {
+            let checkpoint =
+                Checkpoint::new("thread-bench", format!("node-{idx}"), AgentState::new());
+            checkpointer.save(checkpoint).await.unwrap();
+        }
+        checkpointer
+    });
+
+    c.bench_function("checkpoint_list", |b| {
+        b.iter(|| {
+            runtime.block_on(async {
+                let list = populated.list(black_box("thread-bench")).await.unwrap();
+                black_box(list)
+            })
+        })
+    });
+}
+
+fn benchmark_event_dispatch(c: &mut Criterion) {
+    let bus = Arc::new(EventBus::new());
+    let _subscriber = bus.subscribe();
+    let event = Event::graph_started(
+        "thread-bench",
+        Some("perf".to_string()),
+        "router".to_string(),
+    );
+
+    c.bench_function("event_publish", |b| {
+        b.iter(|| {
+            black_box(bus.publish(black_box(event.clone())));
+        })
+    });
+}
+
+fn benchmark_context_pack(c: &mut Criterion) {
+    let retrieval = (0..16)
+        .map(|idx| {
+            let doc = RepositoryDocument::source(
+                "stevedores-org/oxidizedgraph",
+                format!("src/module-{idx}.rs"),
+                format!("context pack benchmark content {idx}"),
+            )
+            .with_symbol(format!("Symbol{idx}"));
+            RetrievalResult {
+                document: doc,
+                score: (idx + 1) as f32,
+                matched_terms: vec!["context".to_string(), "pack".to_string()],
+            }
+        })
+        .collect::<Vec<_>>();
+    let episodes_storage = (0..8)
+        .map(|idx| {
+            EpisodicMemory::new(
+                format!("task-{idx}"),
+                format!("run-{idx}"),
+                "stevedores-org/oxidizedgraph",
+                "Recorded a previous run for context packing.",
+                if idx % 2 == 0 {
+                    RunOutcome::Success
+                } else {
+                    RunOutcome::Failure
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+    let decisions_storage = (0..8)
+        .map(|idx| {
+            DecisionMemory::new(
+                format!("decision-{idx}"),
+                format!("task-{idx}"),
+                "stevedores-org/oxidizedgraph",
+                "use graph execution",
+                "Reduce allocations in the execution hot path.",
+            )
+        })
+        .collect::<Vec<_>>();
+    let episodes = episodes_storage.iter().collect::<Vec<_>>();
+    let decisions = decisions_storage.iter().collect::<Vec<_>>();
+
+    let packer = ContextPacker::new(4_096).reserved_tokens(256);
+    let policy = ContextPolicy::default();
+
+    c.bench_function("context_pack", |b| {
+        b.iter(|| {
+            black_box(packer.pack(
+                black_box(&retrieval),
+                black_box(&episodes),
+                black_box(&decisions),
+                black_box(&policy),
+            ))
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    benchmark_graph_compile,
+    benchmark_graph_invoke,
+    benchmark_checkpoint_save,
+    benchmark_event_dispatch,
+    benchmark_context_pack
+);
+criterion_main!(benches);

--- a/docs/DEPLOY_GKE.md
+++ b/docs/DEPLOY_GKE.md
@@ -91,7 +91,9 @@ If NetworkPolicy/PDB were previously applied into `default`, delete them and re-
 | `/health` | GET | Liveness (k8s probe) |
 | `/readiness` | GET | Readiness (k8s probe) |
 | `/api/v1/sessions` | POST | Create session |
-| `/api/v1/sessions/{id}/execute` | POST | Run graph |
+| `/api/v1/sessions/{id}/execute` | POST | Run the server workflow graph, persist a checkpoint, and return trace metadata |
+| `/api/v1/sessions/{id}/checkpoint` | POST | Persist the current session state as a checkpoint |
+| `/api/v1/sessions/{id}/restore` | POST | Restore a session from a checkpoint payload or checkpoint ID |
 | `/api/v1/sessions/{id}/hitl/status` | GET | HITL pause/request/explanation status |
 | `/api/v1/sessions/{id}/hitl/pause` | POST | Operator pause + checkpoint |
 | `/api/v1/sessions/{id}/hitl/edit` | POST | Queue context edits before resume |

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -118,7 +118,7 @@ fn build_workflow() -> CompiledGraph {
                     (
                         guard
                             .get_context::<serde_json::Value>("input")
-                            .unwrap_or_else(|| serde_json::Value::Null),
+                            .unwrap_or(serde_json::Value::Null),
                         guard.get_context::<String>("run_id").unwrap_or_default(),
                         guard
                             .get_context::<String>("session_id")

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -20,6 +20,8 @@ use uuid::Uuid;
 /// Application state
 struct AppState {
     sessions: RwLock<HashMap<String, SharedState>>,
+    workflow: CompiledGraph,
+    checkpointer: Arc<MemoryCheckpointer>,
 }
 
 /// Health check response
@@ -55,6 +57,12 @@ struct ExecuteResponse {
     session_id: String,
     output: serde_json::Value,
     status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    checkpoint_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transitions: Option<usize>,
 }
 
 /// Error response
@@ -89,6 +97,118 @@ struct HitlDenyRequest {
     rationale: String,
 }
 
+fn build_workflow() -> CompiledGraph {
+    GraphBuilder::new()
+        .name("server-session-workflow")
+        .description("Minimal server-side workflow for session execution")
+        .add_node(FunctionNode::new("prepare_input", |state| async move {
+            let mut guard = state
+                .write()
+                .map_err(|e| NodeError::execution_failed(e.to_string()))?;
+            guard.set_context("execution_stage", "prepared");
+            Ok(NodeOutput::continue_to("finalize_execution"))
+        }))
+        .add_node(FunctionNode::new(
+            "finalize_execution",
+            |state| async move {
+                let (input, run_id, session_id) = {
+                    let guard = state
+                        .read()
+                        .map_err(|e| NodeError::execution_failed(e.to_string()))?;
+                    (
+                        guard
+                            .get_context::<serde_json::Value>("input")
+                            .unwrap_or_else(|| serde_json::Value::Null),
+                        guard.get_context::<String>("run_id").unwrap_or_default(),
+                        guard
+                            .get_context::<String>("session_id")
+                            .unwrap_or_default(),
+                    )
+                };
+
+                let output = serde_json::json!({
+                    "processed": true,
+                    "input": input,
+                    "run_id": run_id,
+                    "session_id": session_id,
+                    "status": "completed",
+                });
+
+                let mut guard = state
+                    .write()
+                    .map_err(|e| NodeError::execution_failed(e.to_string()))?;
+                guard.set_context("execution_output", output);
+                guard.mark_complete();
+                Ok(NodeOutput::finish())
+            },
+        ))
+        .set_entry_point("prepare_input")
+        .add_edge("prepare_input", "finalize_execution")
+        .add_edge_to_end("finalize_execution")
+        .compile()
+        .expect("server workflow graph should compile")
+}
+
+async fn get_session_shared(
+    state: &Arc<AppState>,
+    session_id: &str,
+) -> Result<SharedState, (StatusCode, Json<ErrorResponse>)> {
+    let sessions = state.sessions.read().await;
+    sessions.get(session_id).cloned().ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("Session {session_id} not found"),
+                code: "SESSION_NOT_FOUND",
+            }),
+        )
+    })
+}
+
+async fn write_back_session(
+    shared: &SharedState,
+    state: AgentState,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let mut guard = shared.write().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: format!("Lock error: {e}"),
+                code: "LOCK_ERROR",
+            }),
+        )
+    })?;
+    *guard = state;
+    Ok(())
+}
+
+async fn run_session_workflow(
+    workflow: &CompiledGraph,
+    session_id: &str,
+    state: AgentState,
+) -> Result<TracedRunResult, RuntimeError> {
+    let run_context = RunContext::with_ids(Uuid::new_v4().to_string(), session_id.to_string());
+    let runner = TracedRunner::with_context(workflow.clone(), run_context, RunnerConfig::default());
+    runner.invoke(state).await
+}
+
+fn output_from_state(state: &AgentState) -> serde_json::Value {
+    state
+        .get_context::<serde_json::Value>("execution_output")
+        .unwrap_or_else(|| serde_json::to_value(state).unwrap_or_default())
+}
+
+fn checkpoint_payload(session_id: &str, checkpoint: &Checkpoint) -> serde_json::Value {
+    serde_json::json!({
+        "checkpoint_id": &checkpoint.id,
+        "session_id": session_id,
+        "state": &checkpoint.state,
+        "created_at": &checkpoint.created_at,
+        "parent_id": &checkpoint.parent_id,
+        "metadata": &checkpoint.metadata,
+    })
+}
+
 async fn with_session_mut<F, T>(
     state: &Arc<AppState>,
     session_id: &str,
@@ -97,16 +217,7 @@ async fn with_session_mut<F, T>(
 where
     F: FnOnce(&mut AgentState) -> Result<T, HitlError>,
 {
-    let sessions = state.sessions.read().await;
-    let shared = sessions.get(session_id).ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse {
-                error: format!("Session {session_id} not found"),
-                code: "SESSION_NOT_FOUND",
-            }),
-        )
-    })?;
+    let shared = get_session_shared(state, session_id).await?;
     let mut agent_state = shared.write().map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -146,6 +257,8 @@ async fn main() -> anyhow::Result<()> {
     // Initialize app state
     let state = Arc::new(AppState {
         sessions: RwLock::new(HashMap::new()),
+        workflow: build_workflow(),
+        checkpointer: Arc::new(MemoryCheckpointer::new()),
     });
 
     // Build router
@@ -228,30 +341,18 @@ async fn get_session(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let sessions = state.sessions.read().await;
-
-    match sessions.get(&session_id) {
-        Some(shared_state) => {
-            let agent_state = shared_state.read().map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse {
-                        error: format!("Lock error: {}", e),
-                        code: "LOCK_ERROR",
-                    }),
-                )
-            })?;
-            let data = serde_json::to_value(&*agent_state).unwrap_or_default();
-            Ok(Json(data))
-        }
-        None => Err((
-            StatusCode::NOT_FOUND,
+    let shared_state = get_session_shared(&state, &session_id).await?;
+    let agent_state = shared_state.read().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
-                error: format!("Session {} not found", session_id),
-                code: "SESSION_NOT_FOUND",
+                error: format!("Lock error: {}", e),
+                code: "LOCK_ERROR",
             }),
-        )),
-    }
+        )
+    })?;
+    let data = serde_json::to_value(&*agent_state).unwrap_or_default();
+    Ok(Json(data))
 }
 
 /// Execute a workflow step
@@ -260,46 +361,60 @@ async fn execute(
     Path(session_id): Path<String>,
     Json(req): Json<ExecuteRequest>,
 ) -> Result<Json<ExecuteResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let sessions = state.sessions.read().await;
+    let shared_state = get_session_shared(&state, &session_id).await?;
+    let mut initial_state = shared_state
+        .read()
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("Lock error: {e}"),
+                    code: "LOCK_ERROR",
+                }),
+            )
+        })?
+        .clone();
+    initial_state.set_context("input", req.input.clone());
+    initial_state.set_context("session_id", session_id.clone());
 
-    match sessions.get(&session_id) {
-        Some(shared_state) => {
-            // Update state with input
-            {
-                let mut agent_state = shared_state.write().map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ErrorResponse {
-                            error: format!("Lock error: {}", e),
-                            code: "LOCK_ERROR",
-                        }),
-                    )
-                })?;
-                agent_state.set_context("input", req.input.clone());
-            }
+    let result = run_session_workflow(&state.workflow, &session_id, initial_state)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                    code: "EXECUTION_ERROR",
+                }),
+            )
+        })?;
 
-            // In a real implementation, this would execute the graph
-            // For now, we just echo the input
-            let output = serde_json::json!({
-                "processed": true,
-                "input": req.input,
-                "timestamp": chrono::Utc::now().to_rfc3339(),
-            });
+    write_back_session(&shared_state, result.state.clone()).await?;
 
-            Ok(Json(ExecuteResponse {
-                session_id,
-                output,
-                status: "completed".to_string(),
-            }))
-        }
-        None => Err((
-            StatusCode::NOT_FOUND,
+    let checkpoint = Checkpoint::new(&session_id, "finalize_execution", result.state.clone())
+        .with_metadata(serde_json::json!({
+            "run_id": result.run_context.run_id.clone(),
+            "transition_count": result.transition_log.len(),
+        }));
+    let checkpoint_id = checkpoint.id.clone();
+    state.checkpointer.save(checkpoint).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
-                error: format!("Session {} not found", session_id),
-                code: "SESSION_NOT_FOUND",
+                error: e.to_string(),
+                code: "CHECKPOINT_ERROR",
             }),
-        )),
-    }
+        )
+    })?;
+
+    Ok(Json(ExecuteResponse {
+        session_id,
+        output: output_from_state(&result.state),
+        status: "completed".to_string(),
+        run_id: Some(result.run_context.run_id),
+        checkpoint_id: Some(checkpoint_id),
+        transitions: Some(result.transition_log.len()),
+    }))
 }
 
 /// Create a checkpoint
@@ -307,44 +422,41 @@ async fn checkpoint(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let sessions = state.sessions.read().await;
+    let shared_state = get_session_shared(&state, &session_id).await?;
+    let agent_state = shared_state
+        .read()
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("Lock error: {e}"),
+                    code: "LOCK_ERROR",
+                }),
+            )
+        })?
+        .clone();
+    let checkpoint = Checkpoint::new(&session_id, "manual_checkpoint", agent_state);
+    let checkpoint_id = checkpoint.id.clone();
+    state
+        .checkpointer
+        .save(checkpoint.clone())
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                    code: "CHECKPOINT_ERROR",
+                }),
+            )
+        })?;
 
-    match sessions.get(&session_id) {
-        Some(shared_state) => {
-            let agent_state = shared_state.read().map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse {
-                        error: format!("Lock error: {}", e),
-                        code: "LOCK_ERROR",
-                    }),
-                )
-            })?;
-            let checkpoint_id = Uuid::new_v4().to_string();
+    info!(
+        "Created checkpoint {} for session {}",
+        checkpoint_id, session_id
+    );
 
-            // In production, this would persist to storage
-            let checkpoint_data = serde_json::json!({
-                "checkpoint_id": checkpoint_id,
-                "session_id": session_id,
-                "state": serde_json::to_value(&*agent_state).unwrap_or_default(),
-                "created_at": chrono::Utc::now().to_rfc3339(),
-            });
-
-            info!(
-                "Created checkpoint {} for session {}",
-                checkpoint_id, session_id
-            );
-
-            Ok(Json(checkpoint_data))
-        }
-        None => Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse {
-                error: format!("Session {} not found", session_id),
-                code: "SESSION_NOT_FOUND",
-            }),
-        )),
-    }
+    Ok(Json(checkpoint_payload(&session_id, &checkpoint)))
 }
 
 /// Restore from checkpoint
@@ -353,14 +465,41 @@ async fn restore(
     Path(session_id): Path<String>,
     Json(checkpoint): Json<serde_json::Value>,
 ) -> Result<Json<SessionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let mut sessions = state.sessions.write().await;
-
-    let restored_state = if let Some(state_data) = checkpoint.get("state") {
+    let restored_state = if let Some(checkpoint_id) = checkpoint
+        .get("checkpoint_id")
+        .and_then(|value| value.as_str())
+    {
+        match state
+            .checkpointer
+            .load_by_id(checkpoint_id)
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                        code: "CHECKPOINT_ERROR",
+                    }),
+                )
+            })? {
+            Some(saved) => saved.state,
+            None => {
+                return Err((
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: format!("Checkpoint {checkpoint_id} not found"),
+                        code: "CHECKPOINT_NOT_FOUND",
+                    }),
+                ));
+            }
+        }
+    } else if let Some(state_data) = checkpoint.get("state") {
         serde_json::from_value(state_data.clone()).unwrap_or_else(|_| AgentState::new())
     } else {
-        AgentState::new()
+        serde_json::from_value(checkpoint).unwrap_or_else(|_| AgentState::new())
     };
 
+    let mut sessions = state.sessions.write().await;
     sessions.insert(session_id.clone(), SharedState::new_shared(restored_state));
 
     info!("Restored session {} from checkpoint", session_id);
@@ -375,16 +514,7 @@ async fn hitl_status(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
 ) -> Result<Json<HitlStatus>, (StatusCode, Json<ErrorResponse>)> {
-    let sessions = state.sessions.read().await;
-    let shared = sessions.get(&session_id).ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse {
-                error: format!("Session {session_id} not found"),
-                code: "SESSION_NOT_FOUND",
-            }),
-        )
-    })?;
+    let shared = get_session_shared(&state, &session_id).await?;
     let agent_state = shared.read().map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -458,16 +588,7 @@ async fn hitl_timeline(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
 ) -> Result<Json<RunTimeline>, (StatusCode, Json<ErrorResponse>)> {
-    let sessions = state.sessions.read().await;
-    let shared = sessions.get(&session_id).ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse {
-                error: format!("Session {session_id} not found"),
-                code: "SESSION_NOT_FOUND",
-            }),
-        )
-    })?;
+    let shared = get_session_shared(&state, &session_id).await?;
     let agent_state = shared.read().map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -482,4 +603,43 @@ async fn hitl_timeline(
         .unwrap_or_default();
     let timeline = RunTimeline::from_artifacts(&[], &approvals);
     Ok(Json(timeline))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn server_workflow_executes_real_graph() {
+        let workflow = build_workflow();
+        let mut state = AgentState::new();
+        state.set_context("input", serde_json::json!({"prompt": "hello"}));
+        state.set_context("session_id", "session-1");
+
+        let result = run_session_workflow(&workflow, "session-1", state)
+            .await
+            .unwrap();
+
+        assert_eq!(result.run_context.thread_id, "session-1");
+        assert_eq!(result.transition_log.len(), 2);
+
+        let output: serde_json::Value = result
+            .state
+            .get_context("execution_output")
+            .expect("execution output should be recorded");
+
+        assert_eq!(output["processed"], true);
+        assert_eq!(output["session_id"], "session-1");
+        assert_eq!(output["input"]["prompt"], "hello");
+    }
+
+    #[tokio::test]
+    async fn checkpoint_payload_includes_state_snapshot() {
+        let checkpoint = Checkpoint::new("session-1", "node-a", AgentState::new());
+        let payload = checkpoint_payload("session-1", &checkpoint);
+
+        assert_eq!(payload["session_id"], "session-1");
+        assert_eq!(payload["checkpoint_id"], checkpoint.id);
+        assert!(payload["state"].is_object());
+    }
 }

--- a/src/checkpoint/memory.rs
+++ b/src/checkpoint/memory.rs
@@ -12,18 +12,23 @@ use crate::error::RuntimeError;
 /// Stores checkpoints in memory. Data is lost when the process exits.
 /// For production, use `SurrealCheckpointer` with the `persistence` feature.
 pub struct MemoryCheckpointer {
+    /// Shared checkpoint store.
+    store: RwLock<CheckpointStore>,
+}
+
+#[derive(Default)]
+struct CheckpointStore {
     /// Checkpoints indexed by ID
-    checkpoints: RwLock<HashMap<String, Checkpoint>>,
+    checkpoints: HashMap<String, Checkpoint>,
     /// Thread ID to checkpoint IDs mapping (ordered by creation time)
-    threads: RwLock<HashMap<String, Vec<String>>>,
+    threads: HashMap<String, Vec<String>>,
 }
 
 impl MemoryCheckpointer {
     /// Create a new in-memory checkpointer
     pub fn new() -> Self {
         Self {
-            checkpoints: RwLock::new(HashMap::new()),
-            threads: RwLock::new(HashMap::new()),
+            store: RwLock::new(CheckpointStore::default()),
         }
     }
 }
@@ -40,34 +45,23 @@ impl Checkpointer for MemoryCheckpointer {
         let id = checkpoint.id.clone();
         let thread_id = checkpoint.thread_id.clone();
 
-        // Store the checkpoint
-        {
-            let mut checkpoints = self
-                .checkpoints
-                .write()
-                .map_err(|e| RuntimeError::InvalidState(e.to_string()))?;
-            checkpoints.insert(id.clone(), checkpoint);
-        }
-
-        // Update thread index
-        {
-            let mut threads = self
-                .threads
-                .write()
-                .map_err(|e| RuntimeError::InvalidState(e.to_string()))?;
-            threads.entry(thread_id).or_default().push(id);
-        }
+        let mut store = self
+            .store
+            .write()
+            .map_err(|e| RuntimeError::InvalidState(e.to_string()))?;
+        store.checkpoints.insert(id.clone(), checkpoint);
+        store.threads.entry(thread_id).or_default().push(id);
 
         Ok(())
     }
 
     async fn load(&self, thread_id: &str) -> Result<Option<Checkpoint>, RuntimeError> {
-        let threads = self
-            .threads
+        let store = self
+            .store
             .read()
             .map_err(|e| RuntimeError::InvalidState(e.to_string()))?;
 
-        let checkpoint_ids = match threads.get(thread_id) {
+        let checkpoint_ids = match store.threads.get(thread_id) {
             Some(ids) => ids,
             None => return Ok(None),
         };
@@ -77,65 +71,47 @@ impl Checkpointer for MemoryCheckpointer {
             None => return Ok(None),
         };
 
-        let checkpoints = self
-            .checkpoints
-            .read()
-            .map_err(|e| RuntimeError::InvalidState(e.to_string()))?;
-
-        Ok(checkpoints.get(latest_id).cloned())
+        Ok(store.checkpoints.get(latest_id).cloned())
     }
 
     async fn load_by_id(&self, checkpoint_id: &str) -> Result<Option<Checkpoint>, RuntimeError> {
-        let checkpoints = self
-            .checkpoints
+        let store = self
+            .store
             .read()
             .map_err(|e| RuntimeError::InvalidState(e.to_string()))?;
 
-        Ok(checkpoints.get(checkpoint_id).cloned())
+        Ok(store.checkpoints.get(checkpoint_id).cloned())
     }
 
     async fn list(&self, thread_id: &str) -> Result<Vec<Checkpoint>, RuntimeError> {
-        let threads = self
-            .threads
+        let store = self
+            .store
             .read()
             .map_err(|e| RuntimeError::InvalidState(e.to_string()))?;
 
-        let checkpoint_ids = match threads.get(thread_id) {
+        let checkpoint_ids = match store.threads.get(thread_id) {
             Some(ids) => ids.clone(),
             None => return Ok(Vec::new()),
         };
-
-        let checkpoints = self
-            .checkpoints
-            .read()
-            .map_err(|e| RuntimeError::InvalidState(e.to_string()))?;
 
         // Return in reverse order (newest first)
         let result: Vec<Checkpoint> = checkpoint_ids
             .iter()
             .rev()
-            .filter_map(|id| checkpoints.get(id).cloned())
+            .filter_map(|id| store.checkpoints.get(id).cloned())
             .collect();
 
         Ok(result)
     }
 
     async fn delete(&self, checkpoint_id: &str) -> Result<(), RuntimeError> {
-        let checkpoint = {
-            let mut checkpoints = self
-                .checkpoints
-                .write()
-                .map_err(|e| RuntimeError::InvalidState(e.to_string()))?;
-            checkpoints.remove(checkpoint_id)
-        };
+        let mut store = self
+            .store
+            .write()
+            .map_err(|e| RuntimeError::InvalidState(e.to_string()))?;
 
-        if let Some(cp) = checkpoint {
-            let mut threads = self
-                .threads
-                .write()
-                .map_err(|e| RuntimeError::InvalidState(e.to_string()))?;
-
-            if let Some(ids) = threads.get_mut(&cp.thread_id) {
+        if let Some(cp) = store.checkpoints.remove(checkpoint_id) {
+            if let Some(ids) = store.threads.get_mut(&cp.thread_id) {
                 ids.retain(|id| id != checkpoint_id);
             }
         }
@@ -144,23 +120,14 @@ impl Checkpointer for MemoryCheckpointer {
     }
 
     async fn delete_thread(&self, thread_id: &str) -> Result<(), RuntimeError> {
-        let checkpoint_ids = {
-            let mut threads = self
-                .threads
-                .write()
-                .map_err(|e| RuntimeError::InvalidState(e.to_string()))?;
-            threads.remove(thread_id).unwrap_or_default()
-        };
+        let mut store = self
+            .store
+            .write()
+            .map_err(|e| RuntimeError::InvalidState(e.to_string()))?;
 
-        {
-            let mut checkpoints = self
-                .checkpoints
-                .write()
-                .map_err(|e| RuntimeError::InvalidState(e.to_string()))?;
-
-            for id in checkpoint_ids {
-                checkpoints.remove(&id);
-            }
+        let checkpoint_ids = store.threads.remove(thread_id).unwrap_or_default();
+        for id in checkpoint_ids {
+            store.checkpoints.remove(&id);
         }
 
         Ok(())

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -389,6 +389,7 @@ impl GraphBuilder {
         Ok(CompiledGraph {
             graph,
             node_indices,
+            edge_routes: build_edge_routes(&self.edges),
             edges: self.edges,
             entry_point: entry,
             name: self.name,
@@ -406,10 +407,17 @@ impl GraphBuilder {
 pub struct CompiledGraph {
     pub(crate) graph: StableGraph<GraphNode, GraphEdge>,
     pub(crate) node_indices: HashMap<String, NodeIndex>,
+    pub(crate) edge_routes: HashMap<String, GraphEdgeRoutes>,
     pub(crate) edges: Vec<GraphEdge>,
     pub(crate) entry_point: String,
     pub(crate) name: Option<String>,
     pub(crate) description: Option<String>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct GraphEdgeRoutes {
+    keyed: HashMap<String, GraphEdge>,
+    default: Option<GraphEdge>,
 }
 
 impl CompiledGraph {
@@ -437,30 +445,16 @@ impl CompiledGraph {
         state: &AgentState,
         transition_key: &str,
     ) -> Option<String> {
-        // First, exact transition-key match.
-        for edge in &self.edges {
-            if edge.from != from {
-                continue;
+        if let Some(routes) = self.edge_routes.get(from) {
+            if let Some(edge) = routes.keyed.get(transition_key) {
+                return resolve_edge(edge, state);
             }
-            if edge.transition_key.as_deref() != Some(transition_key) {
-                continue;
-            }
-            return match &edge.edge_type {
-                EdgeType::Direct => Some(edge.to.clone()),
-                EdgeType::Conditional(router) => Some(router(state)),
-            };
-        }
 
-        // Backward compatibility: unkeyed edges are default CONTINUE path.
-        if transition_key == transitions::CONTINUE {
-            for edge in &self.edges {
-                if edge.from != from || edge.transition_key.is_some() {
-                    continue;
+            // Backward compatibility: unkeyed edges are default CONTINUE path.
+            if transition_key == transitions::CONTINUE {
+                if let Some(edge) = routes.default.as_ref() {
+                    return resolve_edge(edge, state);
                 }
-                return match &edge.edge_type {
-                    EdgeType::Direct => Some(edge.to.clone()),
-                    EdgeType::Conditional(router) => Some(router(state)),
-                };
             }
         }
 
@@ -512,6 +506,34 @@ impl CompiledGraph {
 
         output
     }
+}
+
+fn resolve_edge(edge: &GraphEdge, state: &AgentState) -> Option<String> {
+    match &edge.edge_type {
+        EdgeType::Direct => Some(edge.to.clone()),
+        EdgeType::Conditional(router) => Some(router(state)),
+    }
+}
+
+fn build_edge_routes(edges: &[GraphEdge]) -> HashMap<String, GraphEdgeRoutes> {
+    let mut routes: HashMap<String, GraphEdgeRoutes> = HashMap::new();
+
+    for edge in edges {
+        let entry = routes.entry(edge.from.clone()).or_default();
+        match edge.transition_key.as_deref() {
+            Some(key) => {
+                entry
+                    .keyed
+                    .entry(key.to_string())
+                    .or_insert_with(|| edge.clone());
+            }
+            None => {
+                entry.default.get_or_insert_with(|| edge.clone());
+            }
+        }
+    }
+
+    routes
 }
 
 /// Internal END node that terminates execution

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -527,7 +527,12 @@ impl ContextPacker {
         policy: &ContextPolicy,
     ) -> PackedContext {
         let budget = self.max_tokens.saturating_sub(self.reserved_tokens);
-        let mut sections = Vec::new();
+        let mut sections = Vec::with_capacity(
+            policy
+                .max_documents
+                .saturating_add(policy.max_episodes)
+                .saturating_add(policy.max_decisions),
+        );
         let mut estimated_tokens = 0;
         let mut truncated = false;
 


### PR DESCRIPTION
Implements #81 and #82:

- Adds Criterion benches for graph compile/invoke, checkpoint save/list, event publish, and context packing.
- Optimizes graph transition lookup with a precomputed edge index.
- Collapses the in-memory checkpoint store to a single lock.
- Routes oxidizedgraph-server /execute through a real traced workflow and persists checkpoints.
- Adds server tests and updates the GKE deployment doc.