### PR TITLE
fix(diff): resolve topological diff bugs and clean up logic

### DIFF
--- a/examples/autonomous_dev_workflow.rs
+++ b/examples/autonomous_dev_workflow.rs
@@ -55,7 +55,10 @@ async fn main() -> anyhow::Result<()> {
         .add_node(StaticTransitionNode::new("human_review", "done"))
         .add_node(EchoNode::new("review", "Queued for optional human review"))
         .add_node(StaticTransitionNode::new("fix_loop", "implement"))
-        .add_node(EchoNode::new("done", "Workflow complete — ready to open PR"))
+        .add_node(EchoNode::new(
+            "done",
+            "Workflow complete — ready to open PR",
+        ))
         .set_entry_point("implement")
         .add_edge("implement", "quality_gate")
         .add_edge_with_key("quality_gate", "ship", "passed")
@@ -85,7 +88,11 @@ async fn main() -> anyhow::Result<()> {
         println!("Change: {summary}");
     }
     if let Some(gate) = result.state.get_context::<GateResult>("gate_result") {
-        println!("Gate passed: {} (checks: {})", gate.passed, gate.checks.len());
+        println!(
+            "Gate passed: {} (checks: {})",
+            gate.passed,
+            gate.checks.len()
+        );
     }
     if let Some(blocker) = result.state.get_context::<MergeBlocker>("merge_blocker") {
         if blocker.blocked {

--- a/examples/hitl_workflow.rs
+++ b/examples/hitl_workflow.rs
@@ -14,9 +14,10 @@ async fn main() -> anyhow::Result<()> {
         .name("hitl_workflow")
         .add_node(ApprovalCheckpointNode::new("checkpoint"))
         .add_node(EditInterventionNode::new("apply_edits"))
-        .add_node(GrantApprovalNode::new("grant", "operator@example.com").with_rationale(
-            "Reviewed risk summary — proceed with deploy",
-        ))
+        .add_node(
+            GrantApprovalNode::new("grant", "operator@example.com")
+                .with_rationale("Reviewed risk summary — proceed with deploy"),
+        )
         .add_node(EchoNode::new("ship", "Change shipped after approval"))
         .add_node(EchoNode::new("wait", "Paused for operator review"))
         .set_entry_point("checkpoint")
@@ -78,7 +79,10 @@ async fn main() -> anyhow::Result<()> {
     let state = shared.read().unwrap().clone();
     let result = traced.invoke(state).await?;
 
-    if let Some(explanation) = result.state.get_context::<ExplanationPayload>(CTX_EXPLANATION) {
+    if let Some(explanation) = result
+        .state
+        .get_context::<ExplanationPayload>(CTX_EXPLANATION)
+    {
         println!("Summary: {}", explanation.summary);
         println!("Rationale: {}", explanation.rationale);
         if let Some(diff) = &explanation.diff_hint {
@@ -90,7 +94,10 @@ async fn main() -> anyhow::Result<()> {
         println!("Final summary after edit: {summary}");
     }
 
-    if let Some(events) = result.state.get_context::<Vec<ApprovalEvent>>(CTX_APPROVAL_EVENTS) {
+    if let Some(events) = result
+        .state
+        .get_context::<Vec<ApprovalEvent>>(CTX_APPROVAL_EVENTS)
+    {
         println!("Approval events: {}", events.len());
         for event in &events {
             println!("  [{}] {}", event.timestamp, event.kind);

--- a/examples/memory_workflow.rs
+++ b/examples/memory_workflow.rs
@@ -11,8 +11,16 @@ fn main() -> anyhow::Result<()> {
     index.index_documents([
         RepositoryDocument::source(repo, "src/memory.rs", "context packing retrieval ranking")
             .with_symbol("ContextPacker"),
-        RepositoryDocument::source(repo, "src/planning/plan.rs", "EpicPlan task decomposition scheduler"),
-        RepositoryDocument::source(repo, "src/governance/node.rs", "GovernanceNode role guidance manifest"),
+        RepositoryDocument::source(
+            repo,
+            "src/planning/plan.rs",
+            "EpicPlan task decomposition scheduler",
+        ),
+        RepositoryDocument::source(
+            repo,
+            "src/governance/node.rs",
+            "GovernanceNode role guidance manifest",
+        ),
     ]);
 
     let query = RetrievalQuery::new("context packing governance")
@@ -21,7 +29,10 @@ fn main() -> anyhow::Result<()> {
     let hits = index.query(&query);
     println!("Retrieval hits: {}", hits.len());
     for hit in &hits {
-        println!("  {:.2} {} — {:?}", hit.score, hit.document.path, hit.matched_terms);
+        println!(
+            "  {:.2} {} — {:?}",
+            hit.score, hit.document.path, hit.matched_terms
+        );
     }
 
     let mut store = AgentMemoryStore::new();

--- a/examples/multi_agent.rs
+++ b/examples/multi_agent.rs
@@ -118,13 +118,14 @@ async fn main() -> anyhow::Result<()> {
     let coordinator_graph = GraphBuilder::new()
         .name("coordinator")
         .add_node(
-            SubgraphNode::new("ai_research", research_subgraph)
-                .with_result_merger(|parent, child| {
+            SubgraphNode::new("ai_research", research_subgraph).with_result_merger(
+                |parent, child| {
                     // Copy findings to parent with prefix
                     if let Some(findings) = child.get_context::<String>("findings") {
                         parent.set_context("ai_findings", findings);
                     }
-                }),
+                },
+            ),
         )
         .add_node(SynthesizerNode)
         .set_entry_point("ai_research")
@@ -213,9 +214,21 @@ async fn main() -> anyhow::Result<()> {
 
     let results = spawner
         .builder()
-        .spawn("ml", create_researcher_graph("machine_learning", 25), AgentState::new())
-        .spawn("db", create_researcher_graph("databases", 35), AgentState::new())
-        .spawn("net", create_researcher_graph("networking", 20), AgentState::new())
+        .spawn(
+            "ml",
+            create_researcher_graph("machine_learning", 25),
+            AgentState::new(),
+        )
+        .spawn(
+            "db",
+            create_researcher_graph("databases", 35),
+            AgentState::new(),
+        )
+        .spawn(
+            "net",
+            create_researcher_graph("networking", 20),
+            AgentState::new(),
+        )
         .join_all()
         .await;
 

--- a/examples/multirepo_cicd_workflow.rs
+++ b/examples/multirepo_cicd_workflow.rs
@@ -30,8 +30,8 @@ async fn main() -> anyhow::Result<()> {
         .add_edge_to_end("blocked")
         .compile()?;
 
-    let mut change_graph = CrossRepoChangeGraph::new("issue-27", "run-epic9")
-        .with_plan_id("plan-cross-repo");
+    let mut change_graph =
+        CrossRepoChangeGraph::new("issue-27", "run-epic9").with_plan_id("plan-cross-repo");
     change_graph.add_change(RepoChange::new(
         "infra",
         "stevedores-org/infra-code",
@@ -70,14 +70,23 @@ async fn main() -> anyhow::Result<()> {
 
     let result = traced.invoke(state).await?;
 
-    if let Some(ci) = result.state.get_context::<CiAggregateReport>(CTX_CI_AGGREGATE) {
+    if let Some(ci) = result
+        .state
+        .get_context::<CiAggregateReport>(CTX_CI_AGGREGATE)
+    {
         println!(
             "CI aggregate: passed={} failing={:?} pending={:?}",
             ci.passed, ci.failing_repos, ci.pending_repos
         );
     }
-    if let Some(gate) = result.state.get_context::<ReleaseGateResult>(CTX_RELEASE_GATE) {
-        println!("Release gate: can_release={} reason={}", gate.can_release, gate.reason);
+    if let Some(gate) = result
+        .state
+        .get_context::<ReleaseGateResult>(CTX_RELEASE_GATE)
+    {
+        println!(
+            "Release gate: can_release={} reason={}",
+            gate.can_release, gate.reason
+        );
     }
 
     Ok(())

--- a/examples/rag_workflow.rs
+++ b/examples/rag_workflow.rs
@@ -66,7 +66,9 @@ impl NodeExecutor for RAGRetrievalNode {
 
     async fn execute(&self, state: SharedState) -> Result<NodeOutput, NodeError> {
         let query = {
-            let guard = state.read().map_err(|e| NodeError::execution_failed(e.to_string()))?;
+            let guard = state
+                .read()
+                .map_err(|e| NodeError::execution_failed(e.to_string()))?;
             guard.get_context::<String>("query").unwrap_or_default()
         };
 
@@ -79,7 +81,9 @@ impl NodeExecutor for RAGRetrievalNode {
         ];
 
         {
-            let mut guard = state.write().map_err(|e| NodeError::execution_failed(e.to_string()))?;
+            let mut guard = state
+                .write()
+                .map_err(|e| NodeError::execution_failed(e.to_string()))?;
             guard.set_context("retrieved_context", retrieved_context);
         }
 
@@ -102,7 +106,9 @@ impl NodeExecutor for RAGGenerationNode {
 
     async fn execute(&self, state: SharedState) -> Result<NodeOutput, NodeError> {
         let (query, context) = {
-            let guard = state.read().map_err(|e| NodeError::execution_failed(e.to_string()))?;
+            let guard = state
+                .read()
+                .map_err(|e| NodeError::execution_failed(e.to_string()))?;
             let query = guard.get_context::<String>("query").unwrap_or_default();
             let context: Vec<String> = guard.get_context("retrieved_context").unwrap_or_default();
             (query, context)
@@ -117,7 +123,9 @@ impl NodeExecutor for RAGGenerationNode {
         );
 
         {
-            let mut guard = state.write().map_err(|e| NodeError::execution_failed(e.to_string()))?;
+            let mut guard = state
+                .write()
+                .map_err(|e| NodeError::execution_failed(e.to_string()))?;
             guard.set_context("response", response.clone());
             guard.messages.push(Message::assistant(response));
         }
@@ -150,8 +158,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create checkpointing runner for persistence
     let checkpointer = Arc::new(MemoryCheckpointer::new());
-    let runner = CheckpointingRunner::new(graph, checkpointer.clone())
-        .checkpoint_every_node();
+    let runner = CheckpointingRunner::new(graph, checkpointer.clone()).checkpoint_every_node();
 
     // Create initial state with a query
     let mut initial_state = AgentState::new();

--- a/examples/react_agent.rs
+++ b/examples/react_agent.rs
@@ -58,10 +58,7 @@ impl MockLLM {
                     vec![],
                 )
             }
-            _ => (
-                "How can I help you today?".to_string(),
-                vec![],
-            ),
+            _ => ("How can I help you today?".to_string(), vec![]),
         }
     }
 }
@@ -97,9 +94,7 @@ impl Tool for WeatherTool {
     }
 
     async fn execute(&self, arguments: serde_json::Value) -> Result<String, NodeError> {
-        let location = arguments["location"]
-            .as_str()
-            .unwrap_or("Unknown");
+        let location = arguments["location"].as_str().unwrap_or("Unknown");
         Ok(format!("Weather in {}: Sunny, 72°F", location))
     }
 }
@@ -131,9 +126,7 @@ impl Tool for CalculatorTool {
     }
 
     async fn execute(&self, arguments: serde_json::Value) -> Result<String, NodeError> {
-        let expr = arguments["expression"]
-            .as_str()
-            .unwrap_or("0");
+        let expr = arguments["expression"].as_str().unwrap_or("0");
         // Simple mock calculation
         if expr.contains("42 * 17") {
             Ok("714".to_string())
@@ -263,9 +256,9 @@ async fn main() -> anyhow::Result<()> {
     initial_state.messages.push(Message::system(
         "You are a helpful assistant with access to weather and calculator tools.",
     ));
-    initial_state.messages.push(Message::user(
-        "What's the weather like in San Francisco?",
-    ));
+    initial_state
+        .messages
+        .push(Message::user("What's the weather like in San Francisco?"));
 
     println!("User: What's the weather like in San Francisco?\n");
     println!("---\n");

--- a/examples/role_orchestration_workflow.rs
+++ b/examples/role_orchestration_workflow.rs
@@ -35,7 +35,10 @@ impl NodeExecutor for PlanNode {
         let mut guard = state
             .write()
             .map_err(|e| NodeError::execution_failed(e.to_string()))?;
-        guard.set_context("design_note", "Add GovernanceNode + role routing primitives");
+        guard.set_context(
+            "design_note",
+            "Add GovernanceNode + role routing primitives",
+        );
         Ok(NodeOutput::cont())
     }
 }
@@ -70,13 +73,27 @@ async fn main() -> anyhow::Result<()> {
             AgentRole::Architect,
         ))
         .add_node(PlanNode)
-        .add_node(RoleHandoffNode::new("handoff_builder", MANIFEST, AgentRole::Builder))
+        .add_node(RoleHandoffNode::new(
+            "handoff_builder",
+            MANIFEST,
+            AgentRole::Builder,
+        ))
         .add_node(BuildNode)
-        .add_node(RoleHandoffNode::new("handoff_auditor", MANIFEST, AgentRole::Auditor))
+        .add_node(RoleHandoffNode::new(
+            "handoff_auditor",
+            MANIFEST,
+            AgentRole::Auditor,
+        ))
         .add_node(RoleRouterNode::new("role_route", "default"))
-        .add_node(EchoNode::new("audit_lane", "Auditor lane: policy checks complete"))
+        .add_node(EchoNode::new(
+            "audit_lane",
+            "Auditor lane: policy checks complete",
+        ))
         .add_node(EchoNode::new("fallback", "No role set — unexpected"))
-        .add_node(EchoNode::new("done", "Role orchestration workflow complete"))
+        .add_node(EchoNode::new(
+            "done",
+            "Role orchestration workflow complete",
+        ))
         .set_entry_point("gov_architect")
         .add_edge("gov_architect", "plan")
         .add_edge("plan", "handoff_builder")

--- a/examples/simple_workflow.rs
+++ b/examples/simple_workflow.rs
@@ -15,7 +15,7 @@ impl NodeExecutor for ProcessNode {
 
     async fn execute(&self, state: SharedState) -> Result<NodeOutput, NodeError> {
         println!("Processing...");
-        
+
         {
             let mut guard = state
                 .write()
@@ -23,7 +23,7 @@ impl NodeExecutor for ProcessNode {
             guard.add_assistant_message("Processed successfully!");
             guard.set_context("processed", true);
         }
-        
+
         Ok(NodeOutput::cont())
     }
 
@@ -43,16 +43,16 @@ impl NodeExecutor for FinalizeNode {
 
     async fn execute(&self, state: SharedState) -> Result<NodeOutput, NodeError> {
         println!("Finalizing...");
-        
+
         {
             let guard = state
                 .read()
                 .map_err(|e| NodeError::execution_failed(e.to_string()))?;
-            
+
             let processed: bool = guard.get_context("processed").unwrap_or(false);
             println!("Was processed: {}", processed);
         }
-        
+
         Ok(NodeOutput::finish())
     }
 }
@@ -81,12 +81,7 @@ async fn main() -> anyhow::Result<()> {
     let initial_state = AgentState::with_user_message("Hello, process this!");
 
     // Create runner and execute
-    let runner = GraphRunner::new(
-        graph,
-        RunnerConfig::new()
-            .max_iterations(10)
-            .verbose(true),
-    );
+    let runner = GraphRunner::new(graph, RunnerConfig::new().max_iterations(10).verbose(true));
 
     println!("Starting workflow execution...\n");
     let final_state = runner.invoke(initial_state).await?;
@@ -94,7 +89,7 @@ async fn main() -> anyhow::Result<()> {
     println!("\n=== Results ===");
     println!("Total iterations: {}", final_state.iteration);
     println!("Messages: {}", final_state.messages.len());
-    
+
     if let Some(last) = final_state.last_message() {
         println!("Last message: {}", last.content);
     }

--- a/examples/streaming_events.rs
+++ b/examples/streaming_events.rs
@@ -72,10 +72,17 @@ impl EventHandler for TimingHandler {
                 }
                 println!("⏱️  Started: {}", node_id);
             }
-            EventKind::Node(NodeEvent::Exited { node_id, duration_ms, .. }) => {
+            EventKind::Node(NodeEvent::Exited {
+                node_id,
+                duration_ms,
+                ..
+            }) => {
                 println!("✅ Finished: {} ({}ms)", node_id, duration_ms);
             }
-            EventKind::Graph(GraphEvent::Completed { iterations, duration_ms }) => {
+            EventKind::Graph(GraphEvent::Completed {
+                iterations,
+                duration_ms,
+            }) => {
                 println!("\n📊 Graph completed:");
                 println!("   Iterations: {}", iterations);
                 println!("   Total time: {}ms", duration_ms);
@@ -160,7 +167,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Print final state
     println!("\n--- Final State ---");
-    println!("Items processed: {}", result.state().get_context::<i32>("processed").unwrap_or(0));
+    println!(
+        "Items processed: {}",
+        result.state().get_context::<i32>("processed").unwrap_or(0)
+    );
 
     // Cleanup
     drop(bus); // This will close the channel

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -232,17 +232,15 @@ async fn get_session(
 
     match sessions.get(&session_id) {
         Some(shared_state) => {
-            let agent_state = shared_state
-                .read()
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ErrorResponse {
-                            error: format!("Lock error: {}", e),
-                            code: "LOCK_ERROR",
-                        }),
-                    )
-                })?;
+            let agent_state = shared_state.read().map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: format!("Lock error: {}", e),
+                        code: "LOCK_ERROR",
+                    }),
+                )
+            })?;
             let data = serde_json::to_value(&*agent_state).unwrap_or_default();
             Ok(Json(data))
         }
@@ -332,7 +330,10 @@ async fn checkpoint(
                 "created_at": chrono::Utc::now().to_rfc3339(),
             });
 
-            info!("Created checkpoint {} for session {}", checkpoint_id, session_id);
+            info!(
+                "Created checkpoint {} for session {}",
+                checkpoint_id, session_id
+            );
 
             Ok(Json(checkpoint_data))
         }

--- a/src/checkpoint/mod.rs
+++ b/src/checkpoint/mod.rs
@@ -70,7 +70,11 @@ pub struct Checkpoint {
 
 impl Checkpoint {
     /// Create a new checkpoint
-    pub fn new(thread_id: impl Into<String>, node_id: impl Into<String>, state: AgentState) -> Self {
+    pub fn new(
+        thread_id: impl Into<String>,
+        node_id: impl Into<String>,
+        state: AgentState,
+    ) -> Self {
         Self {
             id: Uuid::new_v4().to_string(),
             thread_id: thread_id.into(),
@@ -198,7 +202,9 @@ mod tests {
 
     #[test]
     fn test_checkpoint_config() {
-        let config = CheckpointConfig::every_node().max_per_thread(10).with_branching();
+        let config = CheckpointConfig::every_node()
+            .max_per_thread(10)
+            .with_branching();
 
         assert!(config.checkpoint_every_node);
         assert_eq!(config.max_checkpoints_per_thread, Some(10));

--- a/src/checkpoint/runner.rs
+++ b/src/checkpoint/runner.rs
@@ -21,7 +21,7 @@ pub enum RunResult {
     /// Execution was interrupted (human-in-the-loop)
     Interrupted {
         /// The checkpoint that was saved
-        checkpoint: Checkpoint,
+        checkpoint: Box<Checkpoint>,
         /// Reason for interruption
         reason: String,
     },
@@ -49,7 +49,7 @@ impl RunResult {
     /// Get the checkpoint if interrupted
     pub fn checkpoint(&self) -> Option<&Checkpoint> {
         match self {
-            RunResult::Interrupted { checkpoint, .. } => Some(checkpoint),
+            RunResult::Interrupted { checkpoint, .. } => Some(checkpoint.as_ref()),
             _ => None,
         }
     }

--- a/src/checkpoint/surreal.rs
+++ b/src/checkpoint/surreal.rs
@@ -92,7 +92,9 @@ impl SurrealCheckpointerBuilder {
         db.use_ns(&self.namespace)
             .use_db(&self.database)
             .await
-            .map_err(|e| RuntimeError::InvalidState(format!("SurrealDB use ns/db failed: {}", e)))?;
+            .map_err(|e| {
+                RuntimeError::InvalidState(format!("SurrealDB use ns/db failed: {}", e))
+            })?;
 
         let checkpointer = SurrealCheckpointer { db };
         checkpointer.setup_schema().await?;
@@ -141,8 +143,9 @@ impl TryFrom<CheckpointRecord> for Checkpoint {
     type Error = RuntimeError;
 
     fn try_from(record: CheckpointRecord) -> Result<Self, Self::Error> {
-        let state = serde_json::from_value(record.state)
-            .map_err(|e| RuntimeError::InvalidState(format!("Failed to deserialize state: {}", e)))?;
+        let state = serde_json::from_value(record.state).map_err(|e| {
+            RuntimeError::InvalidState(format!("Failed to deserialize state: {}", e))
+        })?;
 
         let created_at = chrono::DateTime::parse_from_rfc3339(&record.created_at)
             .map_err(|e| RuntimeError::InvalidState(format!("Failed to parse timestamp: {}", e)))?
@@ -170,7 +173,9 @@ impl SurrealCheckpointer {
         db.use_ns("oxidizedgraph")
             .use_db("checkpoints")
             .await
-            .map_err(|e| RuntimeError::InvalidState(format!("SurrealDB use ns/db failed: {}", e)))?;
+            .map_err(|e| {
+                RuntimeError::InvalidState(format!("SurrealDB use ns/db failed: {}", e))
+            })?;
 
         let checkpointer = Self { db };
         checkpointer.setup_schema().await?;
@@ -188,7 +193,9 @@ impl SurrealCheckpointer {
         db.use_ns("oxidizedgraph")
             .use_db("checkpoints")
             .await
-            .map_err(|e| RuntimeError::InvalidState(format!("SurrealDB use ns/db failed: {}", e)))?;
+            .map_err(|e| {
+                RuntimeError::InvalidState(format!("SurrealDB use ns/db failed: {}", e))
+            })?;
 
         let checkpointer = Self { db };
         checkpointer.setup_schema().await?;
@@ -230,7 +237,8 @@ impl Checkpointer for SurrealCheckpointer {
         let record: CheckpointRecord = checkpoint.into();
 
         // Use create with the record's checkpoint_id as the record ID
-        let _: Option<CheckpointRecord> = self.db
+        let _: Option<CheckpointRecord> = self
+            .db
             .create(("checkpoints", record.checkpoint_id.clone()))
             .content(record)
             .await
@@ -259,7 +267,8 @@ impl Checkpointer for SurrealCheckpointer {
     }
 
     async fn load_by_id(&self, checkpoint_id: &str) -> Result<Option<Checkpoint>, RuntimeError> {
-        let record: Option<CheckpointRecord> = self.db
+        let record: Option<CheckpointRecord> = self
+            .db
             .select(("checkpoints", checkpoint_id))
             .await
             .map_err(|e| RuntimeError::InvalidState(format!("Failed to load checkpoint: {}", e)))?;
@@ -274,10 +283,14 @@ impl Checkpointer for SurrealCheckpointer {
         let thread_id = thread_id.to_string();
         let mut result = self
             .db
-            .query("SELECT * FROM checkpoints WHERE thread_id = $thread_id ORDER BY created_at DESC")
+            .query(
+                "SELECT * FROM checkpoints WHERE thread_id = $thread_id ORDER BY created_at DESC",
+            )
             .bind(("thread_id", thread_id))
             .await
-            .map_err(|e| RuntimeError::InvalidState(format!("Failed to list checkpoints: {}", e)))?;
+            .map_err(|e| {
+                RuntimeError::InvalidState(format!("Failed to list checkpoints: {}", e))
+            })?;
 
         let records: Vec<CheckpointRecord> = result
             .take(0)
@@ -287,10 +300,13 @@ impl Checkpointer for SurrealCheckpointer {
     }
 
     async fn delete(&self, checkpoint_id: &str) -> Result<(), RuntimeError> {
-        let _: Option<CheckpointRecord> = self.db
+        let _: Option<CheckpointRecord> = self
+            .db
             .delete(("checkpoints", checkpoint_id))
             .await
-            .map_err(|e| RuntimeError::InvalidState(format!("Failed to delete checkpoint: {}", e)))?;
+            .map_err(|e| {
+                RuntimeError::InvalidState(format!("Failed to delete checkpoint: {}", e))
+            })?;
 
         Ok(())
     }

--- a/src/cicd/change_graph.rs
+++ b/src/cicd/change_graph.rs
@@ -84,10 +84,7 @@ pub struct CrossRepoChangeGraph {
 
 impl CrossRepoChangeGraph {
     /// Create an empty change graph.
-    pub fn new(
-        objective_id: impl Into<String>,
-        run_id: impl Into<String>,
-    ) -> Self {
+    pub fn new(objective_id: impl Into<String>, run_id: impl Into<String>) -> Self {
         Self {
             objective_id: objective_id.into(),
             run_id: run_id.into(),

--- a/src/cicd/ci_aggregate.rs
+++ b/src/cicd/ci_aggregate.rs
@@ -77,12 +77,17 @@ impl CiAggregator {
     }
 
     /// Build a consolidated report from raw CI signals.
-    pub fn aggregate(objective_id: impl Into<String>, signals: &[CiCheckSignal]) -> CiAggregateReport {
+    pub fn aggregate(
+        objective_id: impl Into<String>,
+        signals: &[CiCheckSignal],
+    ) -> CiAggregateReport {
         let objective_id = objective_id.into();
         let mut repo_status: HashMap<String, (bool, bool, bool)> = HashMap::new();
 
         for signal in signals {
-            let entry = repo_status.entry(signal.repo.clone()).or_insert((true, false, false));
+            let entry = repo_status
+                .entry(signal.repo.clone())
+                .or_insert((true, false, false));
             match signal.conclusion {
                 CiConclusion::Failure => {
                     entry.0 = false;

--- a/src/cicd/coordinator.rs
+++ b/src/cicd/coordinator.rs
@@ -150,9 +150,7 @@ mod tests {
     fn sample_graph() -> CrossRepoChangeGraph {
         let mut graph = CrossRepoChangeGraph::new("issue-27", "run-1");
         graph.add_change(RepoChange::new("infra", "org/infra", "Publish module"));
-        graph.add_change(
-            RepoChange::new("lib", "org/lib", "Bump dependency").depends_on("infra"),
-        );
+        graph.add_change(RepoChange::new("lib", "org/lib", "Bump dependency").depends_on("infra"));
         graph.add_change(RepoChange::new("app", "org/app", "Deploy").depends_on("lib"));
         graph
     }
@@ -174,7 +172,13 @@ mod tests {
         coordinator.mark_status(&mut graph, "infra", RepoChangeStatus::CiFailed);
 
         assert!(coordinator.has_rollout_failure(&graph));
-        assert_eq!(graph.get_change("lib").unwrap().status, RepoChangeStatus::Blocked);
-        assert_eq!(graph.get_change("app").unwrap().status, RepoChangeStatus::Blocked);
+        assert_eq!(
+            graph.get_change("lib").unwrap().status,
+            RepoChangeStatus::Blocked
+        );
+        assert_eq!(
+            graph.get_change("app").unwrap().status,
+            RepoChangeStatus::Blocked
+        );
     }
 }

--- a/src/cicd/node.rs
+++ b/src/cicd/node.rs
@@ -204,19 +204,15 @@ impl NodeExecutor for CompleteRepoChangeNode {
             .write()
             .map_err(|e| NodeError::execution_failed(e.to_string()))?;
 
-        let change_id: String = guard
-            .get_context(CTX_CURRENT_REPO_CHANGE)
-            .ok_or_else(|| NodeError::execution_failed("missing current_repo_change".to_string()))?;
+        let change_id: String = guard.get_context(CTX_CURRENT_REPO_CHANGE).ok_or_else(|| {
+            NodeError::execution_failed("missing current_repo_change".to_string())
+        })?;
 
         let mut graph: CrossRepoChangeGraph = guard
             .get_context(CTX_CHANGE_GRAPH)
             .ok_or_else(|| NodeError::execution_failed("missing change_graph".to_string()))?;
 
-        MultiRepoCoordinator::new().mark_status(
-            &mut graph,
-            &change_id,
-            RepoChangeStatus::CiPassed,
-        );
+        MultiRepoCoordinator::new().mark_status(&mut graph, &change_id, RepoChangeStatus::CiPassed);
         guard.set_context(CTX_CHANGE_GRAPH, graph);
         guard.remove_context(CTX_CURRENT_REPO_CHANGE);
 

--- a/src/cicd/release.rs
+++ b/src/cicd/release.rs
@@ -130,11 +130,7 @@ impl ReleaseOrchestrator {
 
     /// Create a release batch from CI-passed changes.
     pub fn create_batch(graph: &CrossRepoChangeGraph, change_ids: &[String]) -> ReleaseBatch {
-        ReleaseBatch::new(
-            &graph.objective_id,
-            &graph.run_id,
-            change_ids.to_vec(),
-        )
+        ReleaseBatch::new(&graph.objective_id, &graph.run_id, change_ids.to_vec())
     }
 }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -187,10 +187,14 @@ impl From<&EdgeType> for EdgeTypeTag {
 
 impl From<&GraphEdge> for EdgeShape {
     fn from(e: &GraphEdge) -> Self {
+        let transition_key = match &e.transition_key {
+            Some(k) if k == transitions::CONTINUE => None,
+            other => other.clone(),
+        };
         Self {
             from: e.from.clone(),
             to: e.to.clone(),
-            transition_key: e.transition_key.clone(),
+            transition_key,
             edge_type: EdgeTypeTag::from(&e.edge_type),
         }
     }
@@ -274,16 +278,20 @@ impl CompiledGraph {
     }
 }
 
+fn node_description(graph: &CompiledGraph, id: &str) -> Option<String> {
+    graph
+        .get_node(id)
+        .and_then(|n| n.executor.description())
+        .map(str::to_string)
+}
+
 fn diff_nodes(before: &CompiledGraph, after: &CompiledGraph) -> Vec<NodeChange> {
     let before_ids = user_node_ids(before);
     let after_ids = user_node_ids(after);
     let mut changes = Vec::new();
 
     for id in before_ids.difference(&after_ids) {
-        let description = before
-            .get_node(id)
-            .and_then(|n| n.executor.description())
-            .map(str::to_string);
+        let description = node_description(before, id);
         changes.push(NodeChange::Removed {
             id: id.clone(),
             description,
@@ -291,10 +299,7 @@ fn diff_nodes(before: &CompiledGraph, after: &CompiledGraph) -> Vec<NodeChange> 
     }
 
     for id in after_ids.difference(&before_ids) {
-        let description = after
-            .get_node(id)
-            .and_then(|n| n.executor.description())
-            .map(str::to_string);
+        let description = node_description(after, id);
         changes.push(NodeChange::Added {
             id: id.clone(),
             description,
@@ -302,14 +307,8 @@ fn diff_nodes(before: &CompiledGraph, after: &CompiledGraph) -> Vec<NodeChange> 
     }
 
     for id in before_ids.intersection(&after_ids) {
-        let b = before
-            .get_node(id)
-            .and_then(|n| n.executor.description())
-            .map(str::to_string);
-        let a = after
-            .get_node(id)
-            .and_then(|n| n.executor.description())
-            .map(str::to_string);
+        let b = node_description(before, id);
+        let a = node_description(after, id);
         if a != b {
             changes.push(NodeChange::DescriptionChanged {
                 id: id.clone(),
@@ -335,31 +334,31 @@ fn user_node_ids(graph: &CompiledGraph) -> BTreeSet<String> {
         .collect()
 }
 
-fn diff_edges(before: &[GraphEdge], after: &[GraphEdge]) -> Vec<EdgeChange> {
-    // Group edges by (from, transition_key) so we can detect "replaced":
-    // same source + transition key, different destination or kind. This
-    // mirrors the runtime's edge-lookup discipline in
-    // CompiledGraph::get_next_node_for_transition.
-    type Key = (String, Option<String>);
-    fn key_of(e: &GraphEdge) -> Key {
-        (e.from.clone(), e.transition_key.clone())
+fn group_by_key(edges: &[GraphEdge]) -> BTreeMap<(String, Option<String>), Vec<&GraphEdge>> {
+    let mut map: BTreeMap<(String, Option<String>), Vec<&GraphEdge>> = BTreeMap::new();
+    for e in edges {
+        if e.from == transitions::END || e.to == transitions::END {
+            continue;
+        }
+        let tk = match &e.transition_key {
+            Some(k) if k == transitions::CONTINUE => None,
+            other => other.clone(),
+        };
+        map.entry((e.from.clone(), tk)).or_default().push(e);
     }
+    map
+}
 
-    let mut before_map: BTreeMap<Key, Vec<&GraphEdge>> = BTreeMap::new();
-    for e in before {
-        before_map.entry(key_of(e)).or_default().push(e);
-    }
-    let mut after_map: BTreeMap<Key, Vec<&GraphEdge>> = BTreeMap::new();
-    for e in after {
-        after_map.entry(key_of(e)).or_default().push(e);
-    }
+fn diff_edges(before: &[GraphEdge], after: &[GraphEdge]) -> Vec<EdgeChange> {
+    let before_map = group_by_key(before);
+    let after_map = group_by_key(after);
 
     let mut changes = Vec::new();
-    let keys: BTreeSet<Key> = before_map.keys().chain(after_map.keys()).cloned().collect();
+    let keys: BTreeSet<_> = before_map.keys().chain(after_map.keys()).collect();
 
     for k in keys {
-        let bs = before_map.get(&k).map(Vec::as_slice).unwrap_or(&[]);
-        let as_ = after_map.get(&k).map(Vec::as_slice).unwrap_or(&[]);
+        let bs = before_map.get(k).map(Vec::as_slice).unwrap_or(&[]);
+        let as_ = after_map.get(k).map(Vec::as_slice).unwrap_or(&[]);
 
         match (bs.len(), as_.len()) {
             (0, _) => {
@@ -386,37 +385,51 @@ fn diff_edges(before: &[GraphEdge], after: &[GraphEdge]) -> Vec<EdgeChange> {
             }
             _ => {
                 // Multiple edges sharing the same (from, transition_key) is
-                // unusual but legal in the builder API. Fall back to a raw
-                // set diff so we don't silently coerce one into a `Replaced`
-                // pairing with an arbitrary partner.
-                let before_set: BTreeSet<EdgeShape> =
-                    bs.iter().map(|e| EdgeShape::from(*e)).collect();
-                let after_set: BTreeSet<EdgeShape> =
-                    as_.iter().map(|e| EdgeShape::from(*e)).collect();
-                for e in before_set.difference(&after_set) {
-                    changes.push(EdgeChange::Removed(e.clone()));
+                // unusual but legal in the builder API. Fall back to a count-aware
+                // multiset diff so we don't silently coerce one into a `Replaced`
+                // pairing with an arbitrary partner and don't drop multiplicity.
+                let mut before_counts = BTreeMap::new();
+                for e in bs {
+                    *before_counts.entry(EdgeShape::from(*e)).or_insert(0) += 1;
                 }
-                for e in after_set.difference(&before_set) {
-                    changes.push(EdgeChange::Added(e.clone()));
+                let mut after_counts = BTreeMap::new();
+                for e in as_ {
+                    *after_counts.entry(EdgeShape::from(*e)).or_insert(0) += 1;
+                }
+
+                let shapes: BTreeSet<&EdgeShape> =
+                    before_counts.keys().chain(after_counts.keys()).collect();
+                for shape in shapes {
+                    let b_count = before_counts.get(shape).copied().unwrap_or(0);
+                    let a_count = after_counts.get(shape).copied().unwrap_or(0);
+                    if b_count > a_count {
+                        for _ in 0..(b_count - a_count) {
+                            changes.push(EdgeChange::Removed(shape.clone()));
+                        }
+                    } else if a_count > b_count {
+                        for _ in 0..(a_count - b_count) {
+                            changes.push(EdgeChange::Added(shape.clone()));
+                        }
+                    }
                 }
             }
         }
     }
 
-    changes.sort_by_key(edge_change_sort_key);
+    changes.sort_by(|a, b| edge_change_sort_key_ref(a).cmp(&edge_change_sort_key_ref(b)));
     changes
 }
 
-fn edge_change_sort_key(e: &EdgeChange) -> (String, Option<String>, String) {
+fn edge_change_sort_key_ref(e: &EdgeChange) -> (&str, Option<&str>, &str) {
     match e {
         EdgeChange::Added(s) | EdgeChange::Removed(s) => {
-            (s.from.clone(), s.transition_key.clone(), s.to.clone())
+            (s.from.as_str(), s.transition_key.as_deref(), s.to.as_str())
         }
         EdgeChange::Replaced {
             from,
             transition_key,
             ..
-        } => (from.clone(), transition_key.clone(), String::new()),
+        } => (from.as_str(), transition_key.as_deref(), ""),
     }
 }
 
@@ -432,26 +445,10 @@ fn diff_metadata(
         return None;
     }
     Some(MetadataChange {
-        name_before: if name_changed {
-            before_name.cloned()
-        } else {
-            None
-        },
-        name_after: if name_changed {
-            after_name.cloned()
-        } else {
-            None
-        },
-        description_before: if desc_changed {
-            before_desc.cloned()
-        } else {
-            None
-        },
-        description_after: if desc_changed {
-            after_desc.cloned()
-        } else {
-            None
-        },
+        name_before: name_changed.then(|| before_name.cloned()).flatten(),
+        name_after: name_changed.then(|| after_name.cloned()).flatten(),
+        description_before: desc_changed.then(|| before_desc.cloned()).flatten(),
+        description_after: desc_changed.then(|| after_desc.cloned()).flatten(),
     })
 }
 
@@ -903,5 +900,116 @@ mod tests {
         // Re-serialize and compare strings; the type isn't PartialEq so this is
         // the simplest way to check round-trip determinism.
         assert_eq!(s, serde_json::to_string(&back).unwrap());
+    }
+
+    #[test]
+    fn synthetic_end_node_and_edges_are_filtered_from_diff() {
+        let before = build(
+            "g",
+            vec![StubNode {
+                id: "x",
+                description: None,
+            }],
+            vec![("x", transitions::END)],
+            "x",
+        );
+        let after = build(
+            "g",
+            vec![StubNode {
+                id: "x",
+                description: None,
+            }],
+            vec![("x", transitions::END)],
+            "x",
+        );
+        let d = before.diff(&after);
+        assert!(d.is_empty(), "expected empty diff, got {d:?}");
+    }
+
+    #[test]
+    fn default_transition_key_normalization() {
+        let mut before_builder = GraphBuilder::new()
+            .name("g")
+            .add_node(StubNode {
+                id: "x",
+                description: None,
+            })
+            .add_node(StubNode {
+                id: "y",
+                description: None,
+            });
+        // Add edge with None transition key
+        before_builder = before_builder.add_edge("x", "y");
+        let before_compiled = before_builder.set_entry_point("x").compile().unwrap();
+
+        let mut after_builder = GraphBuilder::new()
+            .name("g")
+            .add_node(StubNode {
+                id: "x",
+                description: None,
+            })
+            .add_node(StubNode {
+                id: "y",
+                description: None,
+            });
+        // Add edge with explicit "__continue__" key
+        after_builder = after_builder.add_edge_with_key("x", "y", transitions::CONTINUE);
+        let after_compiled = after_builder.set_entry_point("x").compile().unwrap();
+
+        let d = before_compiled.diff(&after_compiled);
+        assert!(
+            d.edge_changes.is_empty(),
+            "expected normalized transition keys to not yield differences: {:?}",
+            d.edge_changes
+        );
+    }
+
+    #[test]
+    fn multiset_diff_preserves_multiplicity() {
+        let before_compiled = GraphBuilder::new()
+            .name("g")
+            .add_node(StubNode {
+                id: "x",
+                description: None,
+            })
+            .add_node(StubNode {
+                id: "y",
+                description: None,
+            })
+            .add_edge("x", "y")
+            .add_edge("x", "y")
+            .set_entry_point("x")
+            .compile()
+            .unwrap();
+
+        let after_compiled = GraphBuilder::new()
+            .name("g")
+            .add_node(StubNode {
+                id: "x",
+                description: None,
+            })
+            .add_node(StubNode {
+                id: "y",
+                description: None,
+            })
+            .add_edge("x", "y")
+            .set_entry_point("x")
+            .compile()
+            .unwrap();
+
+        let d = before_compiled.diff(&after_compiled);
+        assert_eq!(
+            d.edge_changes.len(),
+            1,
+            "expected exactly 1 edge change, got {:?}",
+            d.edge_changes
+        );
+        match &d.edge_changes[0] {
+            EdgeChange::Removed(shape) => {
+                assert_eq!(shape.from, "x");
+                assert_eq!(shape.to, "y");
+            }
+            other => panic!("expected Removed edge change, got {:?}", other),
+        }
     }
 }

--- a/src/enterprise/audit.rs
+++ b/src/enterprise/audit.rs
@@ -261,7 +261,13 @@ mod tests {
             "t1", "run-1", "alice", "execute", "graph", "allowed", "ok",
         ));
         log.append(AuditEventFields::new(
-            "t1", "run-1", "alice", "export", "audit", "completed", "bundle",
+            "t1",
+            "run-1",
+            "alice",
+            "export",
+            "audit",
+            "completed",
+            "bundle",
         ));
         assert!(log.verify_chain());
     }
@@ -270,7 +276,13 @@ mod tests {
     fn export_passes_compliance_checks() {
         let mut log = AuditLog::new();
         log.append(AuditEventFields::new(
-            "t1", "run-1", "alice", "execute", "graph", "allowed", "sanitized detail",
+            "t1",
+            "run-1",
+            "alice",
+            "execute",
+            "graph",
+            "allowed",
+            "sanitized detail",
         ));
         let exporter = ComplianceExporter::new();
         let export = exporter.export_tenant(&log, "t1");

--- a/src/enterprise/mod.rs
+++ b/src/enterprise/mod.rs
@@ -9,9 +9,7 @@ pub mod tenant;
 pub use audit::{
     AuditEventFields, AuditLog, AuditRecord, ComplianceExport, ComplianceExporter, CTX_AUDIT_LOG,
 };
-pub use node::{
-    AuditExportNode, BudgetGuardNode, SecretScopeNode, SloRecordNode, TenantGuardNode,
-};
+pub use node::{AuditExportNode, BudgetGuardNode, SecretScopeNode, SloRecordNode, TenantGuardNode};
 pub use secrets::{
     ScopedCredential, SecretHandle, SecretRedactor, SecretStore, CTX_SCOPED_CREDENTIALS,
 };

--- a/src/enterprise/node.rs
+++ b/src/enterprise/node.rs
@@ -8,7 +8,7 @@ use crate::state::SharedState;
 
 use super::audit::{AuditEventFields, AuditLog, ComplianceExporter, CTX_AUDIT_LOG};
 use super::secrets::{SecretRedactor, CTX_SCOPED_CREDENTIALS};
-use super::slo::{BudgetGuardrail, CostBudget, CTX_COST_BUDGET, CTX_SLO_TRACKER, SloTracker};
+use super::slo::{BudgetGuardrail, CostBudget, SloTracker, CTX_COST_BUDGET, CTX_SLO_TRACKER};
 use super::tenant::{
     Permission, RbacPolicy, RbacSubject, TenantGuard, TenantId, CTX_RBAC_SUBJECT, CTX_TENANT_ID,
 };
@@ -77,11 +77,7 @@ impl NodeExecutor for TenantGuardNode {
             subject.id.clone(),
             "tenant_guard",
             "workflow",
-            if result.allowed {
-                "allowed"
-            } else {
-                "denied"
-            },
+            if result.allowed { "allowed" } else { "denied" },
             detail,
         ));
         guard.set_context(CTX_AUDIT_LOG, audit);
@@ -228,9 +224,7 @@ impl NodeExecutor for SloRecordNode {
             .write()
             .map_err(|e| NodeError::execution_failed(e.to_string()))?;
 
-        let mut tracker: SloTracker = guard
-            .get_context(CTX_SLO_TRACKER)
-            .unwrap_or_default();
+        let mut tracker: SloTracker = guard.get_context(CTX_SLO_TRACKER).unwrap_or_default();
         tracker.record(&self.slo_name, self.success);
         let dashboard = tracker.dashboard();
         guard.set_context(CTX_SLO_TRACKER, tracker);
@@ -272,8 +266,9 @@ impl NodeExecutor for SecretScopeNode {
             .read()
             .map_err(|e| NodeError::execution_failed(e.to_string()))?;
 
-        let credentials: Vec<super::secrets::ScopedCredential> =
-            guard.get_context(CTX_SCOPED_CREDENTIALS).unwrap_or_default();
+        let credentials: Vec<super::secrets::ScopedCredential> = guard
+            .get_context(CTX_SCOPED_CREDENTIALS)
+            .unwrap_or_default();
 
         let has_scope = credentials
             .iter()

--- a/src/enterprise/secrets.rs
+++ b/src/enterprise/secrets.rs
@@ -72,7 +72,9 @@ impl SecretStore {
         if !credential.allows_scope(scope) {
             return None;
         }
-        self.secrets.get(&credential.handle.redacted_ref()).map(|s| s.as_str())
+        self.secrets
+            .get(&credential.handle.redacted_ref())
+            .map(|s| s.as_str())
     }
 }
 
@@ -121,7 +123,10 @@ impl SecretRedactor {
             }
         }
         // Redact ghs_ and ghp_ GitHub tokens
-        for token in find_tokens(output.as_str(), "ghs_").into_iter().chain(find_tokens(output.as_str(), "ghp_")) {
+        for token in find_tokens(output.as_str(), "ghs_")
+            .into_iter()
+            .chain(find_tokens(output.as_str(), "ghp_"))
+        {
             output = output.replace(&token, "[REDACTED_TOKEN]");
         }
         output
@@ -138,7 +143,10 @@ fn find_tokens(input: &str, prefix: &str) -> Vec<String> {
     let mut tokens = Vec::new();
     for word in input.split_whitespace() {
         if word.starts_with(prefix) {
-            tokens.push(word.trim_matches(|c: char| !c.is_alphanumeric() && c != '_').to_string());
+            tokens.push(
+                word.trim_matches(|c: char| !c.is_alphanumeric() && c != '_')
+                    .to_string(),
+            );
         }
     }
     tokens
@@ -160,7 +168,8 @@ mod tests {
     #[test]
     fn redactor_strips_token_patterns() {
         let redactor = SecretRedactor::enterprise_default();
-        let sanitized = redactor.redact("api_key=supersecret123\nAuthorization: Bearer ghs_abc123token");
+        let sanitized =
+            redactor.redact("api_key=supersecret123\nAuthorization: Bearer ghs_abc123token");
         assert!(!sanitized.contains("supersecret123"));
         assert!(!sanitized.contains("ghs_abc123token"));
         assert!(sanitized.contains("[REDACTED]"));

--- a/src/enterprise/tenant.rs
+++ b/src/enterprise/tenant.rs
@@ -41,11 +41,7 @@ pub struct RbacSubject {
 
 impl RbacSubject {
     /// Create a subject with roles.
-    pub fn new(
-        id: impl Into<String>,
-        tenant: TenantId,
-        roles: Vec<RbacRole>,
-    ) -> Self {
+    pub fn new(id: impl Into<String>, tenant: TenantId, roles: Vec<RbacRole>) -> Self {
         Self {
             id: id.into(),
             tenant,
@@ -184,11 +180,8 @@ mod tests {
     fn blocks_cross_tenant_access_for_operator() {
         let guard = TenantGuard::new();
         let policy = RbacPolicy::enterprise_default();
-        let subject = RbacSubject::new(
-            "alice",
-            TenantId::new("tenant-a"),
-            vec![RbacRole::Operator],
-        );
+        let subject =
+            RbacSubject::new("alice", TenantId::new("tenant-a"), vec![RbacRole::Operator]);
         let result = guard.check_access(
             &subject,
             &TenantId::new("tenant-b"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -182,7 +182,10 @@ mod tests {
     #[test]
     fn test_node_error_display() {
         let err = NodeError::execution_failed("Something went wrong");
-        assert_eq!(err.to_string(), "Node execution failed: Something went wrong");
+        assert_eq!(
+            err.to_string(),
+            "Node execution failed: Something went wrong"
+        );
 
         let err = NodeError::Timeout(std::time::Duration::from_secs(30));
         assert!(err.to_string().contains("30"));

--- a/src/events/bus.rs
+++ b/src/events/bus.rs
@@ -103,7 +103,10 @@ impl EventReceiver {
             match receiver.recv().await {
                 Ok(event) => return Some(event),
                 Err(broadcast::error::RecvError::Lagged(skipped)) => {
-                    tracing::warn!(skipped = skipped, "Event receiver lagged, some events were dropped");
+                    tracing::warn!(
+                        skipped = skipped,
+                        "Event receiver lagged, some events were dropped"
+                    );
                     continue; // Try again
                 }
                 Err(broadcast::error::RecvError::Closed) => return None,

--- a/src/events/handler.rs
+++ b/src/events/handler.rs
@@ -6,8 +6,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 use tracing::{debug, error, info, warn};
 
-use super::types::{Event, EventKind, GraphEvent, NodeEvent, CheckpointEvent};
 use super::bus::EventReceiver;
+use super::types::{CheckpointEvent, Event, EventKind, GraphEvent, NodeEvent};
 
 /// Trait for handling events
 #[async_trait]
@@ -48,7 +48,10 @@ impl EventHandler for LoggingHandler {
     async fn handle(&self, event: &Event) {
         match &event.kind {
             EventKind::Graph(graph_event) => match graph_event {
-                GraphEvent::Started { graph_name, entry_point } => {
+                GraphEvent::Started {
+                    graph_name,
+                    entry_point,
+                } => {
                     info!(
                         thread_id = %event.thread_id,
                         graph_name = ?graph_name,
@@ -56,7 +59,10 @@ impl EventHandler for LoggingHandler {
                         "Graph execution started"
                     );
                 }
-                GraphEvent::Completed { iterations, duration_ms } => {
+                GraphEvent::Completed {
+                    iterations,
+                    duration_ms,
+                } => {
                     info!(
                         thread_id = %event.thread_id,
                         iterations = iterations,
@@ -89,7 +95,11 @@ impl EventHandler for LoggingHandler {
                         "Entering node"
                     );
                 }
-                NodeEvent::Exited { node_id, next_node, duration_ms } => {
+                NodeEvent::Exited {
+                    node_id,
+                    next_node,
+                    duration_ms,
+                } => {
                     debug!(
                         thread_id = %event.thread_id,
                         node_id = %node_id,
@@ -106,7 +116,11 @@ impl EventHandler for LoggingHandler {
                         "Node execution failed"
                     );
                 }
-                NodeEvent::Retrying { node_id, attempt, delay_ms } => {
+                NodeEvent::Retrying {
+                    node_id,
+                    attempt,
+                    delay_ms,
+                } => {
                     warn!(
                         thread_id = %event.thread_id,
                         node_id = %node_id,
@@ -117,7 +131,10 @@ impl EventHandler for LoggingHandler {
                 }
             },
             EventKind::Checkpoint(checkpoint_event) => match checkpoint_event {
-                CheckpointEvent::Saved { checkpoint_id, node_id } => {
+                CheckpointEvent::Saved {
+                    checkpoint_id,
+                    node_id,
+                } => {
                     debug!(
                         thread_id = %event.thread_id,
                         checkpoint_id = %checkpoint_id,
@@ -125,7 +142,10 @@ impl EventHandler for LoggingHandler {
                         "Checkpoint saved"
                     );
                 }
-                CheckpointEvent::Restored { checkpoint_id, node_id } => {
+                CheckpointEvent::Restored {
+                    checkpoint_id,
+                    node_id,
+                } => {
                     info!(
                         thread_id = %event.thread_id,
                         checkpoint_id = %checkpoint_id,
@@ -294,7 +314,11 @@ impl EventHandler for MetricsHandler {
             EventKind::Graph(GraphEvent::Error { .. }) => {
                 self.graphs_errored.fetch_add(1, Ordering::Relaxed);
             }
-            EventKind::Node(NodeEvent::Exited { node_id, duration_ms, .. }) => {
+            EventKind::Node(NodeEvent::Exited {
+                node_id,
+                duration_ms,
+                ..
+            }) => {
                 if let Ok(mut m) = self.node_executions.write() {
                     *m.entry(node_id.clone()).or_insert(0) += 1;
                 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -34,9 +34,11 @@ mod runner;
 mod types;
 
 pub use bus::{EventBus, EventReceiver, EventSubscription};
-pub use handler::{EventHandler, LoggingHandler, MetricsHandler, MetricsSummary, NodeMetrics, spawn_handler};
-pub use runner::{StreamingRunner, StreamingRunResult};
-pub use types::{Event, EventKind, NodeEvent, GraphEvent, CheckpointEvent, StateEvent};
+pub use handler::{
+    spawn_handler, EventHandler, LoggingHandler, MetricsHandler, MetricsSummary, NodeMetrics,
+};
+pub use runner::{StreamingRunResult, StreamingRunner};
+pub use types::{CheckpointEvent, Event, EventKind, GraphEvent, NodeEvent, StateEvent};
 
 use std::sync::Arc;
 

--- a/src/events/runner.rs
+++ b/src/events/runner.rs
@@ -22,7 +22,7 @@ pub enum StreamingRunResult {
     /// Execution was interrupted (human-in-the-loop)
     Interrupted {
         /// The checkpoint that was saved
-        checkpoint: Checkpoint,
+        checkpoint: Box<Checkpoint>,
         /// Reason for interruption
         reason: String,
     },

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -67,19 +67,33 @@ impl Event {
     }
 
     /// Create a graph started event
-    pub fn graph_started(thread_id: impl Into<String>, graph_name: Option<String>, entry_point: String) -> Self {
-        Self::new(thread_id, EventKind::Graph(GraphEvent::Started {
-            graph_name,
-            entry_point,
-        }))
+    pub fn graph_started(
+        thread_id: impl Into<String>,
+        graph_name: Option<String>,
+        entry_point: String,
+    ) -> Self {
+        Self::new(
+            thread_id,
+            EventKind::Graph(GraphEvent::Started {
+                graph_name,
+                entry_point,
+            }),
+        )
     }
 
     /// Create a graph completed event
-    pub fn graph_completed(thread_id: impl Into<String>, iterations: u32, duration: Duration) -> Self {
-        Self::new(thread_id, EventKind::Graph(GraphEvent::Completed {
-            iterations,
-            duration_ms: duration.as_millis() as u64,
-        }))
+    pub fn graph_completed(
+        thread_id: impl Into<String>,
+        iterations: u32,
+        duration: Duration,
+    ) -> Self {
+        Self::new(
+            thread_id,
+            EventKind::Graph(GraphEvent::Completed {
+                iterations,
+                duration_ms: duration.as_millis() as u64,
+            }),
+        )
     }
 
     /// Create a graph error event
@@ -89,10 +103,10 @@ impl Event {
 
     /// Create a node entered event
     pub fn node_entered(thread_id: impl Into<String>, node_id: String, iteration: u32) -> Self {
-        Self::new(thread_id, EventKind::Node(NodeEvent::Entered {
-            node_id,
-            iteration,
-        }))
+        Self::new(
+            thread_id,
+            EventKind::Node(NodeEvent::Entered { node_id, iteration }),
+        )
     }
 
     /// Create a node exited event
@@ -102,16 +116,22 @@ impl Event {
         next_node: Option<String>,
         duration: Duration,
     ) -> Self {
-        Self::new(thread_id, EventKind::Node(NodeEvent::Exited {
-            node_id,
-            next_node,
-            duration_ms: duration.as_millis() as u64,
-        }))
+        Self::new(
+            thread_id,
+            EventKind::Node(NodeEvent::Exited {
+                node_id,
+                next_node,
+                duration_ms: duration.as_millis() as u64,
+            }),
+        )
     }
 
     /// Create a node error event
     pub fn node_error(thread_id: impl Into<String>, node_id: String, error: String) -> Self {
-        Self::new(thread_id, EventKind::Node(NodeEvent::Error { node_id, error }))
+        Self::new(
+            thread_id,
+            EventKind::Node(NodeEvent::Error { node_id, error }),
+        )
     }
 
     /// Create a checkpoint saved event
@@ -120,10 +140,13 @@ impl Event {
         checkpoint_id: String,
         node_id: String,
     ) -> Self {
-        Self::new(thread_id, EventKind::Checkpoint(CheckpointEvent::Saved {
-            checkpoint_id,
-            node_id,
-        }))
+        Self::new(
+            thread_id,
+            EventKind::Checkpoint(CheckpointEvent::Saved {
+                checkpoint_id,
+                node_id,
+            }),
+        )
     }
 
     /// Create a checkpoint restored event
@@ -132,10 +155,13 @@ impl Event {
         checkpoint_id: String,
         node_id: String,
     ) -> Self {
-        Self::new(thread_id, EventKind::Checkpoint(CheckpointEvent::Restored {
-            checkpoint_id,
-            node_id,
-        }))
+        Self::new(
+            thread_id,
+            EventKind::Checkpoint(CheckpointEvent::Restored {
+                checkpoint_id,
+                node_id,
+            }),
+        )
     }
 
     /// Create a state updated event
@@ -144,10 +170,13 @@ impl Event {
         node_id: String,
         keys_changed: Vec<String>,
     ) -> Self {
-        Self::new(thread_id, EventKind::State(StateEvent::Updated {
-            node_id,
-            keys_changed,
-        }))
+        Self::new(
+            thread_id,
+            EventKind::State(StateEvent::Updated {
+                node_id,
+                keys_changed,
+            }),
+        )
     }
 
     /// Check if this is a graph event
@@ -321,7 +350,11 @@ mod tests {
 
     #[test]
     fn test_event_creation() {
-        let event = Event::graph_started("thread-1", Some("my_graph".to_string()), "start".to_string());
+        let event = Event::graph_started(
+            "thread-1",
+            Some("my_graph".to_string()),
+            "start".to_string(),
+        );
 
         assert_eq!(event.thread_id, "thread-1");
         assert!(event.is_graph_event());

--- a/src/execution/replay.rs
+++ b/src/execution/replay.rs
@@ -110,8 +110,8 @@ pub fn output_from_record(record: &TransitionRecord) -> NodeOutput {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::transition::TransitionRecord;
+    use super::*;
 
     #[test]
     fn test_output_from_record_preserves_transition_key() {

--- a/src/execution/traced_runner.rs
+++ b/src/execution/traced_runner.rs
@@ -42,7 +42,11 @@ impl TracedRunner {
     }
 
     /// Create a traced runner with explicit run context and config.
-    pub fn with_context(graph: CompiledGraph, run_context: RunContext, config: RunnerConfig) -> Self {
+    pub fn with_context(
+        graph: CompiledGraph,
+        run_context: RunContext,
+        config: RunnerConfig,
+    ) -> Self {
         Self {
             graph,
             config,
@@ -70,7 +74,10 @@ impl TracedRunner {
 
     /// Execute the graph and return state plus trace artifacts.
     #[instrument(skip(self, initial_state), fields(run_id = %self.run_context.run_id))]
-    pub async fn invoke(&self, mut initial_state: AgentState) -> Result<TracedRunResult, RuntimeError> {
+    pub async fn invoke(
+        &self,
+        mut initial_state: AgentState,
+    ) -> Result<TracedRunResult, RuntimeError> {
         attach_run_context(&mut initial_state, &self.run_context);
         if let Some(ref validator) = self.validator {
             validator

--- a/src/execution/validation.rs
+++ b/src/execution/validation.rs
@@ -42,7 +42,11 @@ impl StateValidator {
     }
 
     /// Require a context key to be present with a JSON type (`string`, `number`, etc.).
-    pub fn require_context_type(mut self, key: impl Into<String>, expected_type: &'static str) -> Self {
+    pub fn require_context_type(
+        mut self,
+        key: impl Into<String>,
+        expected_type: &'static str,
+    ) -> Self {
         self.typed_keys.push((key.into(), expected_type));
         self
     }
@@ -141,8 +145,7 @@ mod tests {
 
     #[test]
     fn test_context_type_validation() {
-        let validator =
-            StateValidator::new().require_context_type("gate_passed", "boolean");
+        let validator = StateValidator::new().require_context_type("gate_passed", "boolean");
 
         let mut state = AgentState::new();
         state.set_context("gate_passed", "not-a-bool");

--- a/src/git.rs
+++ b/src/git.rs
@@ -88,9 +88,7 @@ pub fn push(repo_path: impl AsRef<Path>, remote_name: &str, branch: Option<&str>
         Some(b) => b.to_string(),
         None => {
             let head = repo.head().map_err(|_| GitError::NoBranch)?;
-            head.shorthand()
-                .ok_or(GitError::NoBranch)?
-                .to_string()
+            head.shorthand().ok_or(GitError::NoBranch)?.to_string()
         }
     };
 
@@ -131,9 +129,7 @@ where
         Some(b) => b.to_string(),
         None => {
             let head = repo.head().map_err(|_| GitError::NoBranch)?;
-            head.shorthand()
-                .ok_or(GitError::NoBranch)?
-                .to_string()
+            head.shorthand().ok_or(GitError::NoBranch)?.to_string()
         }
     };
 
@@ -161,7 +157,9 @@ fn credential_callback(
         let home = env::var("HOME").unwrap_or_else(|_| ".".to_string());
         for key_name in &["id_ed25519", "id_rsa", "id_ecdsa"] {
             let private_key = Path::new(&home).join(".ssh").join(key_name);
-            let public_key = Path::new(&home).join(".ssh").join(format!("{}.pub", key_name));
+            let public_key = Path::new(&home)
+                .join(".ssh")
+                .join(format!("{}.pub", key_name));
 
             if private_key.exists() {
                 if let Ok(cred) = Cred::ssh_key(username, Some(&public_key), &private_key, None) {

--- a/src/governance/guidance.rs
+++ b/src/governance/guidance.rs
@@ -135,10 +135,7 @@ Builder-only rules.
             &AgentRole::Builder,
             &GovernanceConfig::permissive(),
         );
-        assert_eq!(
-            agent_role_from_state(&state),
-            Some(AgentRole::Builder)
-        );
+        assert_eq!(agent_role_from_state(&state), Some(AgentRole::Builder));
         assert!(state
             .get_context::<String>(CTX_GOVERNANCE_GUIDANCE)
             .unwrap()

--- a/src/governance/mod.rs
+++ b/src/governance/mod.rs
@@ -47,6 +47,4 @@ pub use guidance::{
 pub use node::{GovernanceError, GovernanceNode};
 pub use parser::{blocks_for, parse_blocks, TaggedBlock};
 pub use roles::{AgentRole, RoleParseError};
-pub use routing::{
-    tool_policy_for_state, RoleHandoffNode, RoleRouterNode, RoleTargetRouterNode,
-};
+pub use routing::{tool_policy_for_state, RoleHandoffNode, RoleRouterNode, RoleTargetRouterNode};

--- a/src/governance/node.rs
+++ b/src/governance/node.rs
@@ -35,11 +35,7 @@ pub struct GovernanceNode {
 
 impl GovernanceNode {
     /// Create a node with an inline manifest string.
-    pub fn new(
-        id: impl Into<String>,
-        manifest: impl Into<String>,
-        role: AgentRole,
-    ) -> Self {
+    pub fn new(id: impl Into<String>, manifest: impl Into<String>, role: AgentRole) -> Self {
         Self {
             id: id.into(),
             manifest: manifest.into(),

--- a/src/governance/routing.rs
+++ b/src/governance/routing.rs
@@ -66,11 +66,7 @@ pub struct RoleHandoffNode {
 
 impl RoleHandoffNode {
     /// Create a handoff node with an inline manifest.
-    pub fn new(
-        id: impl Into<String>,
-        manifest: impl Into<String>,
-        next_role: AgentRole,
-    ) -> Self {
+    pub fn new(id: impl Into<String>, manifest: impl Into<String>, next_role: AgentRole) -> Self {
         Self {
             id: id.into(),
             manifest: manifest.into(),
@@ -106,7 +102,10 @@ impl NodeExecutor for RoleHandoffNode {
 }
 
 /// Resolve the tool policy for the active role in state (or a fallback role).
-pub fn tool_policy_for_state(state: &AgentState, fallback: &AgentRole) -> crate::tools::ToolExecutionPolicy {
+pub fn tool_policy_for_state(
+    state: &AgentState,
+    fallback: &AgentRole,
+) -> crate::tools::ToolExecutionPolicy {
     let role = agent_role_from_state(state).unwrap_or_else(|| fallback.clone());
     tool_policy_for_role(&role)
 }

--- a/src/guardrails/gate.rs
+++ b/src/guardrails/gate.rs
@@ -62,7 +62,12 @@ impl MockCommandRunner {
     }
 
     /// Register a result for a check name.
-    pub fn with_result(mut self, name: impl Into<String>, exit_code: i32, output: impl Into<String>) -> Self {
+    pub fn with_result(
+        mut self,
+        name: impl Into<String>,
+        exit_code: i32,
+        output: impl Into<String>,
+    ) -> Self {
         self.results.insert(name.into(), (exit_code, output.into()));
         self
     }

--- a/src/hitl/explain.rs
+++ b/src/hitl/explain.rs
@@ -77,7 +77,8 @@ impl ReviewSummaryBuilder {
         let tool_actions: Vec<String> = state
             .get_context(CTX_RECENT_TOOL_ACTIONS)
             .unwrap_or_default();
-        let findings: Vec<ReviewFinding> = state.get_context(CTX_REVIEW_FINDINGS).unwrap_or_default();
+        let findings: Vec<ReviewFinding> =
+            state.get_context(CTX_REVIEW_FINDINGS).unwrap_or_default();
 
         ReviewSummary {
             summary,

--- a/src/hitl/intervention.rs
+++ b/src/hitl/intervention.rs
@@ -10,9 +10,9 @@ use crate::state::AgentState;
 use super::explain::ReviewSummaryBuilder;
 use super::policy::ApprovalPolicy;
 use super::types::{
-    append_approval_event, ApprovalDecision, ApprovalEvent, ApprovalRequest,
-    ExplanationPayload, InterventionEdit, CTX_APPROVAL_DECISION, CTX_APPROVAL_EVENTS,
-    CTX_APPROVAL_REQUEST, CTX_EXPLANATION, CTX_HITL_EDITS, CTX_HITL_PAUSED,
+    append_approval_event, ApprovalDecision, ApprovalEvent, ApprovalRequest, ExplanationPayload,
+    InterventionEdit, CTX_APPROVAL_DECISION, CTX_APPROVAL_EVENTS, CTX_APPROVAL_REQUEST,
+    CTX_EXPLANATION, CTX_HITL_EDITS, CTX_HITL_PAUSED,
 };
 
 /// Current HITL status for a paused run.
@@ -84,10 +84,9 @@ impl HitlController {
             .get_context::<String>("change_summary")
             .unwrap_or_default();
         let request = ApprovalRequest::new(reason, risk_level).with_summary(summary);
-        let review = self.summarizer.from_state(
-            state,
-            format!("Manual pause: {}", request.reason),
-        );
+        let review = self
+            .summarizer
+            .from_state(state, format!("Manual pause: {}", request.reason));
         let explanation = self.summarizer.to_explanation(&review);
 
         append_approval_event(state, ApprovalEvent::checkpoint_created(&request));
@@ -100,14 +99,15 @@ impl HitlController {
     }
 
     /// Queue operator edits to apply before resume (without losing state).
-    pub fn queue_edits(&self, state: &mut AgentState, edits: InterventionEdit) -> Result<(), HitlError> {
+    pub fn queue_edits(
+        &self,
+        state: &mut AgentState,
+        edits: InterventionEdit,
+    ) -> Result<(), HitlError> {
         if !state.get_context::<bool>(CTX_HITL_PAUSED).unwrap_or(false) {
             return Err(HitlError::NotPaused);
         }
-        append_approval_event(
-            state,
-            ApprovalEvent::intervention_edited(&edits),
-        );
+        append_approval_event(state, ApprovalEvent::intervention_edited(&edits));
         state.set_context(CTX_HITL_EDITS, edits);
         Ok(())
     }

--- a/src/hitl/node.rs
+++ b/src/hitl/node.rs
@@ -66,12 +66,11 @@ impl NodeExecutor for ApprovalCheckpointNode {
         match action {
             ApprovalAction::Allow => Ok(NodeOutput::transition("approved")),
             ApprovalAction::Deny => {
-                let request =
-                    ApprovalRequest::new("Policy denied action", risk).with_summary(
-                        guard
-                            .get_context::<String>("change_summary")
-                            .unwrap_or_default(),
-                    );
+                let request = ApprovalRequest::new("Policy denied action", risk).with_summary(
+                    guard
+                        .get_context::<String>("change_summary")
+                        .unwrap_or_default(),
+                );
                 append_approval_event(&mut guard, ApprovalEvent::checkpoint_created(&request));
                 guard.set_context(CTX_APPROVAL_REQUEST, request);
                 guard.set_context(CTX_HITL_PAUSED, true);
@@ -81,17 +80,13 @@ impl NodeExecutor for ApprovalCheckpointNode {
                 let summary = guard
                     .get_context::<String>("change_summary")
                     .unwrap_or_else(|| "Autonomous change pending review".to_string());
-                let request = ApprovalRequest::new(
-                    format!("{risk:?} change requires human approval"),
-                    risk,
-                )
-                .with_summary(&summary);
+                let request =
+                    ApprovalRequest::new(format!("{risk:?} change requires human approval"), risk)
+                        .with_summary(&summary);
 
                 let summarizer = ReviewSummaryBuilder::new();
-                let review = summarizer.from_state(
-                    &guard,
-                    format!("Risk level {risk:?} matched pause policy"),
-                );
+                let review = summarizer
+                    .from_state(&guard, format!("Risk level {risk:?} matched pause policy"));
                 let explanation = summarizer.to_explanation(&review);
                 append_approval_event(&mut guard, ApprovalEvent::checkpoint_created(&request));
                 guard.set_context(CTX_APPROVAL_REQUEST, request);
@@ -143,9 +138,10 @@ impl NodeExecutor for GrantApprovalNode {
             .write()
             .map_err(|e| NodeError::execution_failed(e.to_string()))?;
 
-        let request: ApprovalRequest = guard.get_context(CTX_APPROVAL_REQUEST).ok_or_else(|| {
-            NodeError::execution_failed("no approval_request in context".to_string())
-        })?;
+        let request: ApprovalRequest =
+            guard.get_context(CTX_APPROVAL_REQUEST).ok_or_else(|| {
+                NodeError::execution_failed("no approval_request in context".to_string())
+            })?;
 
         let mut decision = ApprovalDecision::approve(&request.id, &self.approver);
         decision.rationale = self.rationale.clone();
@@ -246,7 +242,9 @@ mod tests {
 
         let guard = shared.read().unwrap();
         assert!(guard.get_context::<bool>(CTX_HITL_PAUSED).unwrap());
-        assert!(guard.get_context::<ApprovalRequest>(CTX_APPROVAL_REQUEST).is_some());
+        assert!(guard
+            .get_context::<ApprovalRequest>(CTX_APPROVAL_REQUEST)
+            .is_some());
     }
 
     #[tokio::test]
@@ -261,7 +259,9 @@ mod tests {
         grant.execute(shared.clone()).await.unwrap();
 
         let guard = shared.read().unwrap();
-        let decision = guard.get_context::<ApprovalDecision>(CTX_APPROVAL_DECISION).unwrap();
+        let decision = guard
+            .get_context::<ApprovalDecision>(CTX_APPROVAL_DECISION)
+            .unwrap();
         assert_eq!(decision.status, ApprovalStatus::Approved);
         assert!(!guard.get_context::<bool>(CTX_HITL_PAUSED).unwrap());
     }

--- a/src/hitl/timeline.rs
+++ b/src/hitl/timeline.rs
@@ -30,10 +30,7 @@ pub struct RunTimeline {
 
 impl RunTimeline {
     /// Build a timeline from transition records and approval events.
-    pub fn from_artifacts(
-        transitions: &[TransitionRecord],
-        approvals: &[ApprovalEvent],
-    ) -> Self {
+    pub fn from_artifacts(transitions: &[TransitionRecord], approvals: &[ApprovalEvent]) -> Self {
         let mut entries = Vec::new();
         let mut seq = 0usize;
 
@@ -68,10 +65,7 @@ impl RunTimeline {
 
     /// Number of approval events in the timeline.
     pub fn approval_count(&self) -> usize {
-        self.entries
-            .iter()
-            .filter(|e| e.kind == "approval")
-            .count()
+        self.entries.iter().filter(|e| e.kind == "approval").count()
     }
 }
 

--- a/src/nodes/conditional.rs
+++ b/src/nodes/conditional.rs
@@ -140,7 +140,9 @@ impl BranchNode {
     }
 
     /// Add a branch that checks a context value
-    pub fn branch_on_context<T: for<'de> serde::Deserialize<'de> + PartialEq + Send + Sync + 'static>(
+    pub fn branch_on_context<
+        T: for<'de> serde::Deserialize<'de> + PartialEq + Send + Sync + 'static,
+    >(
         self,
         key: impl Into<String>,
         expected: T,
@@ -148,7 +150,12 @@ impl BranchNode {
     ) -> Self {
         let key = key.into();
         self.branch(
-            move |state| state.get_context::<T>(&key).map(|v| v == expected).unwrap_or(false),
+            move |state| {
+                state
+                    .get_context::<T>(&key)
+                    .map(|v| v == expected)
+                    .unwrap_or(false)
+            },
             target,
         )
     }
@@ -193,12 +200,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_conditional_node_true() {
-        let node = ConditionalNode::new(
-            "cond",
-            |state| state.is_complete,
-            "done",
-            "continue",
-        );
+        let node = ConditionalNode::new("cond", |state| state.is_complete, "done", "continue");
 
         let mut state = AgentState::new();
         state.is_complete = true;
@@ -210,12 +212,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_conditional_node_false() {
-        let node = ConditionalNode::new(
-            "cond",
-            |state| state.is_complete,
-            "done",
-            "continue",
-        );
+        let node = ConditionalNode::new("cond", |state| state.is_complete, "done", "continue");
 
         let state = AgentState::new();
         let shared = Arc::new(RwLock::new(state));
@@ -243,7 +240,9 @@ mod tests {
         let node = ConditionalNode::has_tool_calls("check", "execute_tools", "respond");
 
         let mut state = AgentState::new();
-        state.tool_calls.push(ToolCall::new("1", "test", serde_json::json!({})));
+        state
+            .tool_calls
+            .push(ToolCall::new("1", "test", serde_json::json!({})));
         let shared = Arc::new(RwLock::new(state));
 
         let result = node.execute(shared).await.unwrap();

--- a/src/nodes/function.rs
+++ b/src/nodes/function.rs
@@ -13,8 +13,11 @@ use crate::graph::{NodeExecutor, NodeOutput};
 use crate::state::SharedState;
 
 /// Type alias for the async function signature
-pub type AsyncNodeFn =
-    Arc<dyn Fn(SharedState) -> Pin<Box<dyn Future<Output = Result<NodeOutput, NodeError>> + Send>> + Send + Sync>;
+pub type AsyncNodeFn = Arc<
+    dyn Fn(SharedState) -> Pin<Box<dyn Future<Output = Result<NodeOutput, NodeError>> + Send>>
+        + Send
+        + Sync,
+>;
 
 /// A node that wraps a closure for execution
 pub struct FunctionNode {

--- a/src/nodes/llm.rs
+++ b/src/nodes/llm.rs
@@ -325,15 +325,23 @@ mod tests {
         struct NoToolProvider;
         #[async_trait]
         impl LLMProvider for NoToolProvider {
-            async fn generate(&self, _m: &[Message], _c: &LLMConfig) -> Result<LLMResponse, NodeError> {
+            async fn generate(
+                &self,
+                _m: &[Message],
+                _c: &LLMConfig,
+            ) -> Result<LLMResponse, NodeError> {
                 Ok(LLMResponse::text("No tools here"))
             }
-            fn name(&self) -> &str { "mock" }
+            fn name(&self) -> &str {
+                "mock"
+            }
         }
 
         let node = LLMNode::with_provider("llm", NoToolProvider);
         let mut state = AgentState::new();
-        state.tool_calls.push(ToolCall::new("old", "old_tool", serde_json::json!({})));
+        state
+            .tool_calls
+            .push(ToolCall::new("old", "old_tool", serde_json::json!({})));
         let shared = Arc::new(RwLock::new(state));
 
         let _ = node.execute(shared.clone()).await.unwrap();

--- a/src/nodes/quality_gate.rs
+++ b/src/nodes/quality_gate.rs
@@ -1,2 +1,4 @@
 //! Re-export quality gate node from guardrails module.
-pub use crate::guardrails::{CommandRunner, CommandSpec, MockCommandRunner, QualityGateConfig, QualityGateNode};
+pub use crate::guardrails::{
+    CommandRunner, CommandSpec, MockCommandRunner, QualityGateConfig, QualityGateNode,
+};

--- a/src/nodes/tool.rs
+++ b/src/nodes/tool.rs
@@ -150,7 +150,10 @@ impl ToolRegistry {
                 Ok(PolicyDecision::RequireApproval) => {
                     return ToolResult::error(
                         &call.id,
-                        format!("Tool '{}' requires human approval before execution", call.name),
+                        format!(
+                            "Tool '{}' requires human approval before execution",
+                            call.name
+                        ),
                     );
                 }
                 Ok(PolicyDecision::Deny) => {
@@ -229,7 +232,11 @@ impl ToolNode {
     }
 
     /// Create a tool node with execution configuration.
-    pub fn with_config(id: impl Into<String>, registry: ToolRegistry, config: ToolNodeConfig) -> Self {
+    pub fn with_config(
+        id: impl Into<String>,
+        registry: ToolRegistry,
+        config: ToolNodeConfig,
+    ) -> Self {
         Self {
             id: id.into(),
             registry,
@@ -262,11 +269,7 @@ impl NodeExecutor for ToolNode {
         for call in &tool_calls {
             let result = self
                 .registry
-                .execute_with_policy(
-                    call,
-                    self.config.policy.as_ref(),
-                    self.config.tool_timeout,
-                )
+                .execute_with_policy(call, self.config.policy.as_ref(), self.config.tool_timeout)
                 .await;
             results.push(result);
         }
@@ -279,10 +282,9 @@ impl NodeExecutor for ToolNode {
 
             // Add tool results as messages
             for result in results {
-                guard.messages.push(Message::tool_result(
-                    &result.tool_call_id,
-                    result.as_str(),
-                ));
+                guard
+                    .messages
+                    .push(Message::tool_result(&result.tool_call_id, result.as_str()));
             }
 
             // Clear pending tool calls
@@ -451,15 +453,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_tool_registry() {
-        let tool = FunctionTool::new(
-            "greet",
-            "Greets someone",
-            serde_json::json!({}),
-            |args| {
-                let name = args["name"].as_str().unwrap_or("World");
-                Ok(format!("Hello, {}!", name))
-            },
-        );
+        let tool = FunctionTool::new("greet", "Greets someone", serde_json::json!({}), |args| {
+            let name = args["name"].as_str().unwrap_or("World");
+            Ok(format!("Hello, {}!", name))
+        });
 
         let registry = ToolRegistry::new().register(tool);
 
@@ -474,20 +471,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_tool_node() {
-        let tool = FunctionTool::new(
-            "echo",
-            "Echoes input",
-            serde_json::json!({}),
-            |args| Ok(args["message"].as_str().unwrap_or("").to_string()),
-        );
+        let tool = FunctionTool::new("echo", "Echoes input", serde_json::json!({}), |args| {
+            Ok(args["message"].as_str().unwrap_or("").to_string())
+        });
 
         let registry = ToolRegistry::new().register(tool);
         let node = ToolNode::new("tools", registry);
 
         let mut state = AgentState::new();
-        state
-            .tool_calls
-            .push(ToolCall::new("1", "echo", serde_json::json!({"message": "Hello"})));
+        state.tool_calls.push(ToolCall::new(
+            "1",
+            "echo",
+            serde_json::json!({"message": "Hello"}),
+        ));
 
         let shared = Arc::new(RwLock::new(state));
         let result = node.execute(shared.clone()).await.unwrap();

--- a/src/orchestration/handle.rs
+++ b/src/orchestration/handle.rs
@@ -65,12 +65,10 @@ impl SubgraphResult {
         match self {
             SubgraphResult::Completed { state, .. } => Ok(state),
             SubgraphResult::Failed { error, .. } => Err(error),
-            SubgraphResult::Cancelled { subgraph_id } => {
-                Err(RuntimeError::InvalidState(format!(
-                    "Subgraph '{}' was cancelled",
-                    subgraph_id
-                )))
-            }
+            SubgraphResult::Cancelled { subgraph_id } => Err(RuntimeError::InvalidState(format!(
+                "Subgraph '{}' was cancelled",
+                subgraph_id
+            ))),
         }
     }
 
@@ -97,7 +95,10 @@ pub struct SubgraphHandle {
 impl SubgraphHandle {
     /// Create a new subgraph handle
     pub(crate) fn new(subgraph_id: String, handle: JoinHandle<SubgraphResult>) -> Self {
-        Self { subgraph_id, handle }
+        Self {
+            subgraph_id,
+            handle,
+        }
     }
 
     /// Get the subgraph ID

--- a/src/orchestration/parallel.rs
+++ b/src/orchestration/parallel.rs
@@ -186,14 +186,8 @@ impl ParallelSubgraphs {
             let handle = tokio::spawn(async move {
                 let runner = GraphRunner::new((*graph).clone(), config);
                 match runner.invoke(child_state).await {
-                    Ok(state) => SubgraphResult::Completed {
-                        subgraph_id,
-                        state,
-                    },
-                    Err(error) => SubgraphResult::Failed {
-                        subgraph_id,
-                        error,
-                    },
+                    Ok(state) => SubgraphResult::Completed { subgraph_id, state },
+                    Err(error) => SubgraphResult::Failed { subgraph_id, error },
                 }
             });
 
@@ -336,11 +330,8 @@ impl NodeExecutor for ParallelSubgraphs {
         );
 
         // Create a map of subgraph configs by ID for merger lookup
-        let config_map: HashMap<&str, &SubgraphConfig> = self
-            .subgraphs
-            .iter()
-            .map(|c| (c.id.as_str(), c))
-            .collect();
+        let config_map: HashMap<&str, &SubgraphConfig> =
+            self.subgraphs.iter().map(|c| (c.id.as_str(), c)).collect();
 
         // Merge results back into parent state
         {
@@ -349,7 +340,10 @@ impl NodeExecutor for ParallelSubgraphs {
                 .map_err(|e| NodeError::execution_failed(e.to_string()))?;
 
             for (id, result) in results {
-                if let SubgraphResult::Completed { state: child_state, .. } = result {
+                if let SubgraphResult::Completed {
+                    state: child_state, ..
+                } = result
+                {
                     if let Some(config) = config_map.get(id.as_str()) {
                         (config.result_merger)(&mut guard, child_state);
                     }
@@ -416,8 +410,14 @@ mod tests {
     #[tokio::test]
     async fn test_parallel_subgraphs_wait_all() {
         let parallel = ParallelSubgraphs::new("parallel")
-            .add_subgraph("fast", create_delayed_graph("fast", "fast_result", "fast_value", 10))
-            .add_subgraph("slow", create_delayed_graph("slow", "slow_result", "slow_value", 50))
+            .add_subgraph(
+                "fast",
+                create_delayed_graph("fast", "fast_result", "fast_value", 10),
+            )
+            .add_subgraph(
+                "slow",
+                create_delayed_graph("slow", "slow_result", "slow_value", 50),
+            )
             .with_join_strategy(JoinStrategy::WaitAll);
 
         let state = Arc::new(RwLock::new(AgentState::new()));
@@ -445,13 +445,17 @@ mod tests {
     async fn test_parallel_fail_fast() {
         let parallel = ParallelSubgraphs::new("parallel")
             .add_subgraph("slow", create_delayed_graph("slow", "s", "v", 1000))
-            .add_subgraph("fast_fail", GraphBuilder::new()
-                .add_node(crate::nodes::function::FunctionNode::new("fail", |_| async {
-                    Err(NodeError::execution_failed("intentional failure"))
-                }))
-                .set_entry_point("fail")
-                .compile()
-                .unwrap())
+            .add_subgraph(
+                "fast_fail",
+                GraphBuilder::new()
+                    .add_node(crate::nodes::function::FunctionNode::new(
+                        "fail",
+                        |_| async { Err(NodeError::execution_failed("intentional failure")) },
+                    ))
+                    .set_entry_point("fail")
+                    .compile()
+                    .unwrap(),
+            )
             .with_join_strategy(JoinStrategy::FailFast);
 
         let state = Arc::new(RwLock::new(AgentState::new()));
@@ -468,13 +472,17 @@ mod tests {
     async fn test_parallel_wait_all_propagates_failure() {
         let parallel = ParallelSubgraphs::new("parallel")
             .add_subgraph("ok", create_delayed_graph("ok", "k", "v", 10))
-            .add_subgraph("fail", GraphBuilder::new()
-                .add_node(crate::nodes::function::FunctionNode::new("fail", |_| async {
-                    Err(NodeError::execution_failed("intentional failure"))
-                }))
-                .set_entry_point("fail")
-                .compile()
-                .unwrap())
+            .add_subgraph(
+                "fail",
+                GraphBuilder::new()
+                    .add_node(crate::nodes::function::FunctionNode::new(
+                        "fail",
+                        |_| async { Err(NodeError::execution_failed("intentional failure")) },
+                    ))
+                    .set_entry_point("fail")
+                    .compile()
+                    .unwrap(),
+            )
             .with_join_strategy(JoinStrategy::WaitAll);
 
         let state = Arc::new(RwLock::new(AgentState::new()));
@@ -522,13 +530,17 @@ mod tests {
     async fn test_parallel_wait_n_fail_fast_on_error() {
         let parallel = ParallelSubgraphs::new("parallel")
             .add_subgraph("ok", create_delayed_graph("ok", "ok", "v", 10))
-            .add_subgraph("fail", GraphBuilder::new()
-                .add_node(crate::nodes::function::FunctionNode::new("fail", |_| async {
-                    Err(NodeError::execution_failed("intentional failure"))
-                }))
-                .set_entry_point("fail")
-                .compile()
-                .unwrap())
+            .add_subgraph(
+                "fail",
+                GraphBuilder::new()
+                    .add_node(crate::nodes::function::FunctionNode::new(
+                        "fail",
+                        |_| async { Err(NodeError::execution_failed("intentional failure")) },
+                    ))
+                    .set_entry_point("fail")
+                    .compile()
+                    .unwrap(),
+            )
             .add_subgraph("slow", create_delayed_graph("slow", "slow", "v", 1000))
             .with_join_strategy(JoinStrategy::WaitN(2));
 

--- a/src/orchestration/spawner.rs
+++ b/src/orchestration/spawner.rs
@@ -73,7 +73,9 @@ impl SubgraphSpawner {
 
     /// Generate a unique subgraph ID
     pub fn generate_id(&self, prefix: &str) -> String {
-        let n = self.counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let n = self
+            .counter
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         format!("{}-{}", prefix, n)
     }
 
@@ -142,10 +144,7 @@ impl SubgraphSpawner {
 
     /// Get the number of currently active subgraphs
     pub fn active_count(&self) -> usize {
-        self.active
-            .read()
-            .map(|m| m.len())
-            .unwrap_or(0)
+        self.active.read().map(|m| m.len()).unwrap_or(0)
     }
 
     /// Check if any subgraphs are still running
@@ -197,7 +196,9 @@ impl<'a> SpawnBuilder<'a> {
         parent_state: &AgentState,
         mapper: &StateMapper,
     ) -> Self {
-        let handle = self.spawner.spawn_with_mapper(subgraph_id, graph, parent_state, mapper);
+        let handle = self
+            .spawner
+            .spawn_with_mapper(subgraph_id, graph, parent_state, mapper);
         self.handles.push(handle);
         self
     }
@@ -292,7 +293,10 @@ mod tests {
 
         assert!(result.is_completed());
         let state = result.state().unwrap();
-        assert_eq!(state.get_context::<String>("result"), Some("hello".to_string()));
+        assert_eq!(
+            state.get_context::<String>("result"),
+            Some("hello".to_string())
+        );
     }
 
     #[tokio::test]

--- a/src/planning/mod.rs
+++ b/src/planning/mod.rs
@@ -13,4 +13,4 @@ pub use node::{PlanningNode, SchedulerNode};
 pub use plan::{EpicPlan, Task, TaskStatus};
 pub use progress::PlanProgress;
 pub use scheduler::Scheduler;
-pub use self_healing::{FailureClass, RetryPolicy, RecoveryRecord, classify_failure};
+pub use self_healing::{classify_failure, FailureClass, RecoveryRecord, RetryPolicy};

--- a/src/planning/node.rs
+++ b/src/planning/node.rs
@@ -7,7 +7,7 @@ use crate::graph::{NodeExecutor, NodeOutput};
 use crate::planning::plan::{EpicPlan, Task, TaskStatus};
 use crate::planning::progress::PlanProgress;
 use crate::planning::scheduler::Scheduler;
-use crate::planning::self_healing::{FailureClass, RetryPolicy, RecoveryRecord, classify_failure};
+use crate::planning::self_healing::{classify_failure, FailureClass, RecoveryRecord, RetryPolicy};
 use crate::state::SharedState;
 
 /// Type alias for the goal decomposer closure.
@@ -162,26 +162,33 @@ impl NodeExecutor for SchedulerNode {
         }
 
         if has_failures {
-            let mut attempts: HashMap<String, usize> = guard.get_context("task_attempts").unwrap_or_default();
-            let mut history: Vec<RecoveryRecord> = guard.get_context("recovery_history").unwrap_or_default();
+            let mut attempts: HashMap<String, usize> =
+                guard.get_context("task_attempts").unwrap_or_default();
+            let mut history: Vec<RecoveryRecord> =
+                guard.get_context("recovery_history").unwrap_or_default();
             let mut replanned_all = true;
             let mut replanned_any = false;
 
             for failed_id in failed_ids {
                 let task = plan.get_task(&failed_id).unwrap().clone();
-                let error_msg = task.error.clone().unwrap_or_else(|| "Unknown error".to_string());
+                let error_msg = task
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "Unknown error".to_string());
 
                 if self.self_healing_enabled {
                     let class = classify_failure(&error_msg);
-                    let policy = self.retry_policies.get(&class).cloned().unwrap_or_else(|| {
-                        match class {
-                            FailureClass::Compile => RetryPolicy::compile_default(),
-                            FailureClass::Test => RetryPolicy::test_default(),
-                            FailureClass::Runtime => RetryPolicy::runtime_default(),
-                            FailureClass::Integration => RetryPolicy::integration_default(),
-                            FailureClass::Unknown => RetryPolicy::default(),
-                        }
-                    });
+                    let policy =
+                        self.retry_policies
+                            .get(&class)
+                            .cloned()
+                            .unwrap_or_else(|| match class {
+                                FailureClass::Compile => RetryPolicy::compile_default(),
+                                FailureClass::Test => RetryPolicy::test_default(),
+                                FailureClass::Runtime => RetryPolicy::runtime_default(),
+                                FailureClass::Integration => RetryPolicy::integration_default(),
+                                FailureClass::Unknown => RetryPolicy::default(),
+                            });
 
                     let current_attempts = *attempts.get(&failed_id).unwrap_or(&0);
 
@@ -190,11 +197,14 @@ impl NodeExecutor for SchedulerNode {
                         attempts.insert(failed_id.clone(), attempt);
 
                         // If a manual recovery is registered, use it, else generate dynamically
-                        let recovery = if let Some(manual_rec) = self.auto_replan_recoveries.get(&failed_id).cloned() {
+                        let recovery = if let Some(manual_rec) =
+                            self.auto_replan_recoveries.get(&failed_id).cloned()
+                        {
                             manual_rec
                         } else {
                             let rec_id = format!("recovery_{}_{}", failed_id, attempt);
-                            let rec_name = format!("Remediate {} failure in {}", class.as_str(), task.name);
+                            let rec_name =
+                                format!("Remediate {} failure in {}", class.as_str(), task.name);
                             let rec_desc = format!(
                                 "Self-healing task injected for {} (Attempt {}/{}) due to: {}",
                                 task.id, attempt, policy.max_attempts, error_msg
@@ -211,7 +221,7 @@ impl NodeExecutor for SchedulerNode {
                             format!(
                                 "Classified as {:?}. Injected recovery task {}/{} attempts.",
                                 class, attempt, policy.max_attempts
-                            )
+                            ),
                         );
                         history.push(record);
 
@@ -237,7 +247,7 @@ impl NodeExecutor for SchedulerNode {
                             format!(
                                 "Exceeded max attempts ({}) for failure class {:?}",
                                 policy.max_attempts, class
-                            )
+                            ),
                         );
                         history.push(record);
 

--- a/src/planning/self_healing.rs
+++ b/src/planning/self_healing.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 /// Taxonomy of task execution failures.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -76,17 +76,17 @@ pub use crate::governance::{
 
 // Planning and autonomy (roadmap EPIC6/EPIC7)
 pub use crate::planning::{
-    EpicPlan, PlanProgress, PlanningNode, Scheduler, SchedulerNode, Task, TaskStatus,
-    FailureClass, RetryPolicy, RecoveryRecord, classify_failure,
+    classify_failure, EpicPlan, FailureClass, PlanProgress, PlanningNode, RecoveryRecord,
+    RetryPolicy, Scheduler, SchedulerNode, Task, TaskStatus,
 };
 
 // Human-in-the-loop controls (roadmap EPIC8)
 pub use crate::hitl::{
-    append_approval_event, ApprovalAction, ApprovalCheckpointNode, ApprovalDecision,
-    ApprovalEvent, ApprovalMatrix, ApprovalPolicy, ApprovalRequest, ApprovalStatus,
-    ApproverRole, EditInterventionNode, ExplanationPayload, GrantApprovalNode, HitlController,
-    HitlError, HitlStatus, InterventionEdit, ResumeNode, ReviewSummary, ReviewSummaryBuilder,
-    RunTimeline, TimelineEntry, CTX_APPROVAL_DECISION, CTX_APPROVAL_EVENTS, CTX_APPROVAL_REQUEST,
+    append_approval_event, ApprovalAction, ApprovalCheckpointNode, ApprovalDecision, ApprovalEvent,
+    ApprovalMatrix, ApprovalPolicy, ApprovalRequest, ApprovalStatus, ApproverRole,
+    EditInterventionNode, ExplanationPayload, GrantApprovalNode, HitlController, HitlError,
+    HitlStatus, InterventionEdit, ResumeNode, ReviewSummary, ReviewSummaryBuilder, RunTimeline,
+    TimelineEntry, CTX_APPROVAL_DECISION, CTX_APPROVAL_EVENTS, CTX_APPROVAL_REQUEST,
     CTX_EXPLANATION, CTX_HITL_EDITS, CTX_HITL_PAUSED, CTX_PROPOSED_DIFF, CTX_RECENT_TOOL_ACTIONS,
     CTX_REVIEW_FINDINGS,
 };
@@ -94,19 +94,19 @@ pub use crate::hitl::{
 // Multi-repo CI/CD orchestration (roadmap EPIC9)
 pub use crate::cicd::{
     CiAggregateNode, CiAggregateReport, CiAggregator, CiCheckSignal, CiConclusion,
-    CompleteRepoChangeNode, CrossRepoChangeGraph, MultiRepoCoordinator,
-    MultiRepoCoordinatorNode, ReleaseBatch, ReleaseGateNode, ReleaseGateResult,
-    ReleaseOrchestrator, RepoChange, RepoChangeStatus, CTX_CHANGE_GRAPH, CTX_CI_AGGREGATE,
-    CTX_CURRENT_REPO_CHANGE, CTX_RELEASE_GATE,
+    CompleteRepoChangeNode, CrossRepoChangeGraph, MultiRepoCoordinator, MultiRepoCoordinatorNode,
+    ReleaseBatch, ReleaseGateNode, ReleaseGateResult, ReleaseOrchestrator, RepoChange,
+    RepoChangeStatus, CTX_CHANGE_GRAPH, CTX_CI_AGGREGATE, CTX_CURRENT_REPO_CHANGE,
+    CTX_RELEASE_GATE,
 };
 
 // Enterprise readiness (roadmap EPIC10)
 pub use crate::enterprise::{
-    AuditExportNode, AuditEventFields, AuditLog, AuditRecord, BudgetDecision, BudgetGuardNode, BudgetGuardrail,
-    ComplianceExport, ComplianceExporter, CostBudget, Permission, RbacPolicy, RbacRole,
-    RbacSubject, ScopedCredential, SecretHandle, SecretRedactor, SecretScopeNode, SecretStore,
-    SloObservation, SloRecordNode, SloTarget, SloTracker, TenantBoundaryResult, TenantGuard,
-    TenantGuardNode, TenantId, CTX_AUDIT_LOG, CTX_COST_BUDGET, CTX_RBAC_SUBJECT,
+    AuditEventFields, AuditExportNode, AuditLog, AuditRecord, BudgetDecision, BudgetGuardNode,
+    BudgetGuardrail, ComplianceExport, ComplianceExporter, CostBudget, Permission, RbacPolicy,
+    RbacRole, RbacSubject, ScopedCredential, SecretHandle, SecretRedactor, SecretScopeNode,
+    SecretStore, SloObservation, SloRecordNode, SloTarget, SloTracker, TenantBoundaryResult,
+    TenantGuard, TenantGuardNode, TenantId, CTX_AUDIT_LOG, CTX_COST_BUDGET, CTX_RBAC_SUBJECT,
     CTX_SCOPED_CREDENTIALS, CTX_SLO_TRACKER, CTX_TENANT_ID,
 };
 

--- a/src/tools/policy.rs
+++ b/src/tools/policy.rs
@@ -112,7 +112,11 @@ impl ToolPolicyEngine {
     }
 
     /// Evaluate whether a tool may run.
-    pub fn evaluate(&self, tool_name: &str, command_hint: Option<&str>) -> Result<PolicyDecision, PolicyViolation> {
+    pub fn evaluate(
+        &self,
+        tool_name: &str,
+        command_hint: Option<&str>,
+    ) -> Result<PolicyDecision, PolicyViolation> {
         if self.policy.denied_tools.contains(tool_name) {
             return Ok(PolicyDecision::Deny);
         }

--- a/src/tools/sandbox.rs
+++ b/src/tools/sandbox.rs
@@ -145,7 +145,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_subprocess_sandbox_timeout() {
-        let sandbox = SubprocessSandbox::new(SandboxConfig::with_timeout(Duration::from_millis(50)));
+        let sandbox =
+            SubprocessSandbox::new(SandboxConfig::with_timeout(Duration::from_millis(50)));
         let result = sandbox.run("sleep 2", None).await;
         assert!(matches!(result, Err(SandboxError::Timeout(_))));
     }

--- a/tests/cicd_epic9.rs
+++ b/tests/cicd_epic9.rs
@@ -6,9 +6,7 @@ use std::sync::{Arc, RwLock};
 fn sample_graph() -> CrossRepoChangeGraph {
     let mut graph = CrossRepoChangeGraph::new("issue-27", "run-1");
     graph.add_change(RepoChange::new("infra", "org/infra", "Publish module"));
-    graph.add_change(
-        RepoChange::new("app", "org/app", "Deploy service").depends_on("infra"),
-    );
+    graph.add_change(RepoChange::new("app", "org/app", "Deploy service").depends_on("infra"));
     graph
 }
 
@@ -61,7 +59,10 @@ async fn epic9_graph_walks_infra_then_app() {
     let first = coordinator.execute(shared.clone()).await.unwrap();
     assert_eq!(first.target(), Some("execute_change"));
     assert_eq!(
-        shared.read().unwrap().get_context::<String>(CTX_CURRENT_REPO_CHANGE),
+        shared
+            .read()
+            .unwrap()
+            .get_context::<String>(CTX_CURRENT_REPO_CHANGE),
         Some("infra".to_string())
     );
 
@@ -70,7 +71,10 @@ async fn epic9_graph_walks_infra_then_app() {
     let second = coordinator.execute(shared.clone()).await.unwrap();
     assert_eq!(second.target(), Some("execute_change"));
     assert_eq!(
-        shared.read().unwrap().get_context::<String>(CTX_CURRENT_REPO_CHANGE),
+        shared
+            .read()
+            .unwrap()
+            .get_context::<String>(CTX_CURRENT_REPO_CHANGE),
         Some("app".to_string())
     );
 }

--- a/tests/enterprise_epic10.rs
+++ b/tests/enterprise_epic10.rs
@@ -6,11 +6,7 @@ use oxidizedgraph::prelude::*;
 fn tenant_boundary_blocks_cross_tenant_operator() {
     let guard = TenantGuard::new();
     let policy = RbacPolicy::enterprise_default();
-    let subject = RbacSubject::new(
-        "bob",
-        TenantId::new("tenant-a"),
-        vec![RbacRole::Operator],
-    );
+    let subject = RbacSubject::new("bob", TenantId::new("tenant-a"), vec![RbacRole::Operator]);
     let result = guard.check_access(
         &subject,
         &TenantId::new("tenant-b"),
@@ -89,8 +85,5 @@ async fn tenant_guard_node_denies_cross_tenant() {
     let runner = GraphRunner::with_defaults(graph);
     let result = runner.invoke(state).await.unwrap();
     let audit: AuditLog = result.get_context(CTX_AUDIT_LOG).unwrap();
-    assert!(audit
-        .records()
-        .iter()
-        .any(|r| r.outcome == "denied"));
+    assert!(audit.records().iter().any(|r| r.outcome == "denied"));
 }

--- a/tests/governance_epic2.rs
+++ b/tests/governance_epic2.rs
@@ -117,12 +117,20 @@ async fn epic2_graph_walks_architect_to_auditor() {
             id: "plan",
             key: "planned",
         })
-        .add_node(RoleHandoffNode::new("to_builder", MANIFEST, AgentRole::Builder))
+        .add_node(RoleHandoffNode::new(
+            "to_builder",
+            MANIFEST,
+            AgentRole::Builder,
+        ))
         .add_node(MarkNode {
             id: "build",
             key: "built",
         })
-        .add_node(RoleHandoffNode::new("to_auditor", MANIFEST, AgentRole::Auditor))
+        .add_node(RoleHandoffNode::new(
+            "to_auditor",
+            MANIFEST,
+            AgentRole::Auditor,
+        ))
         .add_node(RoleRouterNode::new("route", "default"))
         .add_node(MarkNode {
             id: "audit",
@@ -144,8 +152,5 @@ async fn epic2_graph_walks_architect_to_auditor() {
     assert!(result.get_context::<bool>("planned").unwrap());
     assert!(result.get_context::<bool>("built").unwrap());
     assert!(result.get_context::<bool>("audited").unwrap());
-    assert_eq!(
-        agent_role_from_state(&result),
-        Some(AgentRole::Auditor)
-    );
+    assert_eq!(agent_role_from_state(&result), Some(AgentRole::Auditor));
 }

--- a/tests/graph_patterns.rs
+++ b/tests/graph_patterns.rs
@@ -86,7 +86,11 @@ async fn multi_branch_conditional_routing() {
     }
 
     // Build separate graphs for each branch since CompiledGraph isn't Clone.
-    for (route, expected) in [("path_a", ",path_a"), ("path_b", ",path_b"), ("path_c", ",path_c")] {
+    for (route, expected) in [
+        ("path_a", ",path_a"),
+        ("path_b", ",path_b"),
+        ("path_c", ",path_c"),
+    ] {
         let graph = GraphBuilder::new()
             .add_node(RouterNode)
             .add_node(TrackingNode::new("path_a"))
@@ -325,7 +329,10 @@ async fn conditional_edge_routing() {
 
     let visited: String = result.get_context("visited").unwrap_or_default();
     assert!(visited.contains("start"), "start should have run");
-    assert!(visited.contains("yes_branch"), "should route to yes_branch when not complete");
+    assert!(
+        visited.contains("yes_branch"),
+        "should route to yes_branch when not complete"
+    );
 }
 
 #[tokio::test]
@@ -364,7 +371,10 @@ async fn node_output_finish_stops_immediately() {
     assert_eq!(result.get_context::<bool>("finished"), Some(true));
     // "unreachable" should never have run
     let visited: Option<String> = result.get_context("visited");
-    assert!(visited.is_none(), "unreachable node should not have executed");
+    assert!(
+        visited.is_none(),
+        "unreachable node should not have executed"
+    );
 }
 
 #[tokio::test]

--- a/tests/hitl_epic8.rs
+++ b/tests/hitl_epic8.rs
@@ -1,7 +1,7 @@
 //! Integration tests for EPIC8 human-in-the-loop (#26).
 
-use oxidizedgraph::prelude::*;
 use oxidizedgraph::hitl::{CTX_APPROVAL_EVENTS, CTX_HITL_PAUSED};
+use oxidizedgraph::prelude::*;
 use std::sync::{Arc, RwLock};
 
 #[tokio::test]
@@ -17,7 +17,9 @@ async fn epic8_checkpoint_pauses_high_risk_change() {
 
     let guard = shared.read().unwrap();
     assert!(guard.get_context::<bool>(CTX_HITL_PAUSED).unwrap());
-    let events = guard.get_context::<Vec<ApprovalEvent>>(CTX_APPROVAL_EVENTS).unwrap();
+    let events = guard
+        .get_context::<Vec<ApprovalEvent>>(CTX_APPROVAL_EVENTS)
+        .unwrap();
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].kind, "checkpoint_created");
 }
@@ -51,8 +53,8 @@ async fn epic8_low_risk_skips_pause() {
 
 #[test]
 fn epic8_timeline_merges_transitions_and_approvals() {
-    use oxidizedgraph::execution::TransitionRecord;
     use chrono::Utc;
+    use oxidizedgraph::execution::TransitionRecord;
 
     let transitions = vec![TransitionRecord {
         run_id: "r1".into(),

--- a/tests/memory_epic5.rs
+++ b/tests/memory_epic5.rs
@@ -65,11 +65,7 @@ fn epic5_decision_memory_is_queryable() {
 fn epic5_context_packer_respects_token_budget() {
     let mut index = RepositoryIndex::new();
     let content = "retrieval ".repeat(200);
-    index.index_document(RepositoryDocument::source(
-        REPO,
-        "src/memory.rs",
-        content,
-    ));
+    index.index_document(RepositoryDocument::source(REPO, "src/memory.rs", content));
 
     let hits = index.query(&RetrievalQuery::new("retrieval").limit(1));
     let packer = ContextPacker::new(100);

--- a/tests/self_healing_epic7.rs
+++ b/tests/self_healing_epic7.rs
@@ -3,11 +3,26 @@ use std::sync::{Arc, RwLock};
 
 #[tokio::test]
 async fn test_failure_classification() {
-    assert_eq!(classify_failure("Compilation failed in main.rs:32"), FailureClass::Compile);
-    assert_eq!(classify_failure("cargo build returned error status 101"), FailureClass::Compile);
-    assert_eq!(classify_failure("test failed: assert_eq!(a, b)"), FailureClass::Test);
-    assert_eq!(classify_failure("Connection refused to api.example.com"), FailureClass::Integration);
-    assert_eq!(classify_failure("thread panicked at index out of bounds"), FailureClass::Runtime);
+    assert_eq!(
+        classify_failure("Compilation failed in main.rs:32"),
+        FailureClass::Compile
+    );
+    assert_eq!(
+        classify_failure("cargo build returned error status 101"),
+        FailureClass::Compile
+    );
+    assert_eq!(
+        classify_failure("test failed: assert_eq!(a, b)"),
+        FailureClass::Test
+    );
+    assert_eq!(
+        classify_failure("Connection refused to api.example.com"),
+        FailureClass::Integration
+    );
+    assert_eq!(
+        classify_failure("thread panicked at index out of bounds"),
+        FailureClass::Runtime
+    );
     assert_eq!(classify_failure("some weird error"), FailureClass::Unknown);
 }
 
@@ -50,7 +65,9 @@ async fn test_self_healing_retry_bounds() {
         assert_eq!(rec.status, TaskStatus::Pending);
 
         // Check history
-        let history = guard.get_context::<Vec<RecoveryRecord>>("recovery_history").unwrap();
+        let history = guard
+            .get_context::<Vec<RecoveryRecord>>("recovery_history")
+            .unwrap();
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].task_id, "t1");
         assert_eq!(history[0].attempt, 1);
@@ -80,7 +97,9 @@ async fn test_self_healing_retry_bounds() {
         let t1 = updated_plan.get_task("t1").unwrap();
         assert_eq!(t1.dependencies, vec!["recovery_t1_2".to_string()]);
 
-        let history = guard.get_context::<Vec<RecoveryRecord>>("recovery_history").unwrap();
+        let history = guard
+            .get_context::<Vec<RecoveryRecord>>("recovery_history")
+            .unwrap();
         assert_eq!(history.len(), 2);
         assert_eq!(history[1].attempt, 2);
     }
@@ -104,7 +123,9 @@ async fn test_self_healing_retry_bounds() {
 
     {
         let guard = state.read().unwrap();
-        let history = guard.get_context::<Vec<RecoveryRecord>>("recovery_history").unwrap();
+        let history = guard
+            .get_context::<Vec<RecoveryRecord>>("recovery_history")
+            .unwrap();
         assert_eq!(history.len(), 3);
         assert_eq!(history[2].decision, "Halted (max attempts)");
         assert!(history[2].rationale.contains("Exceeded max attempts"));


### PR DESCRIPTION
This PR resolves the topological diff bugs in oxidizedgraph issues/75.

### Changes:
- **Synthetic END filtering**: Excluded synthetic `__end__` edges from diffs.
- **Transition normalization**: Normalized `Some("__continue__")` transition keys to `None`.
- **Multiset Diff fallback**: Replaced the deduplicating set diff with a count-aware multiset diff using BTreeMap counts to preserve multiplicity.
- **Refactoring cleanups**: DRY'd description lookups, collapsed metadata assignment pattern, extracted edge grouping, and optimized sorting keys to avoid clones.
- **Clippy and Fmt**: Addressed large enum variant warnings by boxing the checkpoint field in RunResult and StreamingRunResult, and auto-formatted the codebase.