### PR TITLE
fix(clippy): use unwrap_or instead of unwrap_or_else for Value::Null

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -167,7 +167,7 @@ fn build_workflow() -> CompiledGraph {
                     (
                         guard
                             .get_context::<serde_json::Value>("input")
-                            .unwrap_or_else(|| serde_json::Value::Null),
+                            .unwrap_or(serde_json::Value::Null),
                         guard.get_context::<String>("run_id").unwrap_or_default(),
                         guard
                             .get_context::<String>("session_id")


### PR DESCRIPTION
## Summary

One-line clippy fix. `cargo clippy --all-targets -- -D warnings` on `main` fails with:

```
error: unnecessary closure used to substitute value for `Option::None`
   --> src/bin/server.rs:168:25
    |
168 | /                         guard
169 | |                             .get_context::<serde_json::Value>("input")
170 | |                             .unwrap_or_else(|| serde_json::Value::Null),
    | |_______________________________________________________________________^
    = note: `-D clippy::unnecessary-lazy-evaluations` implied by `-D warnings`
help: use `unwrap_or` instead
```

`serde_json::Value::Null` is a unit-like enum variant — no allocation, no
function call — so `unwrap_or_else(|| Value::Null)` is just `unwrap_or(Value::Null)`
with extra closure ceremony. Switching to the eager form clears the lint.

## Why this is a one-line PR

This was the only blocker for `cargo clippy --all-targets -- -D warnings`
on `main`. PR #88 surfaced it (its CI failed on this line, not on PR
code), and #88 was admin-merged over it. Fixing it here unblocks normal
CI for all future PRs.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --all-targets` — passes
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
