### PR TITLE
fix: Handle final exact iteration limit gracefully

### DIFF
--- a/src/checkpoint/runner.rs
+++ b/src/checkpoint/runner.rs
@@ -191,6 +191,22 @@ impl<C: Checkpointer> CheckpointingRunner<C> {
         );
 
         loop {
+            // Check for END node
+            if current_node == transitions::END {
+                info!(
+                    thread_id = %thread_id,
+                    iterations = iterations,
+                    "Graph execution completed"
+                );
+
+                let final_state = state
+                    .read()
+                    .map_err(|e| RuntimeError::InvalidState(e.to_string()))?
+                    .clone();
+
+                return Ok(RunResult::Completed(final_state));
+            }
+
             // Check iteration limit
             if iterations >= self.config.max_iterations {
                 warn!(
@@ -209,22 +225,6 @@ impl<C: Checkpointer> CheckpointingRunner<C> {
                 self.checkpointer.save(checkpoint).await?;
 
                 return Err(RuntimeError::RecursionLimit(self.config.max_iterations));
-            }
-
-            // Check for END node
-            if current_node == transitions::END {
-                info!(
-                    thread_id = %thread_id,
-                    iterations = iterations,
-                    "Graph execution completed"
-                );
-
-                let final_state = state
-                    .read()
-                    .map_err(|e| RuntimeError::InvalidState(e.to_string()))?
-                    .clone();
-
-                return Ok(RunResult::Completed(final_state));
             }
 
             // Get the current node

--- a/src/events/runner.rs
+++ b/src/events/runner.rs
@@ -183,6 +183,29 @@ impl<C: Checkpointer> StreamingRunner<C> {
         ));
 
         loop {
+            // Check for END node
+            if current_node == transitions::END {
+                let duration = graph_start.elapsed();
+
+                // Emit graph completed event
+                self.event_bus
+                    .publish(Event::graph_completed(thread_id, iterations, duration));
+
+                info!(
+                    thread_id = %thread_id,
+                    iterations = iterations,
+                    duration_ms = duration.as_millis(),
+                    "Graph execution completed"
+                );
+
+                let final_state = state
+                    .read()
+                    .map_err(|e| RuntimeError::InvalidState(e.to_string()))?
+                    .clone();
+
+                return Ok(StreamingRunResult::Completed(final_state));
+            }
+
             // Check iteration limit
             if iterations >= self.config.max_iterations {
                 warn!(
@@ -211,29 +234,6 @@ impl<C: Checkpointer> StreamingRunner<C> {
                 }
 
                 return Err(RuntimeError::RecursionLimit(self.config.max_iterations));
-            }
-
-            // Check for END node
-            if current_node == transitions::END {
-                let duration = graph_start.elapsed();
-
-                // Emit graph completed event
-                self.event_bus
-                    .publish(Event::graph_completed(thread_id, iterations, duration));
-
-                info!(
-                    thread_id = %thread_id,
-                    iterations = iterations,
-                    duration_ms = duration.as_millis(),
-                    "Graph execution completed"
-                );
-
-                let final_state = state
-                    .read()
-                    .map_err(|e| RuntimeError::InvalidState(e.to_string()))?
-                    .clone();
-
-                return Ok(StreamingRunResult::Completed(final_state));
             }
 
             // Get the current node

--- a/tests/test_exact_iterations.rs
+++ b/tests/test_exact_iterations.rs
@@ -1,0 +1,86 @@
+use oxidizedgraph::prelude::*;
+
+#[tokio::test]
+async fn test_runner_exact_iterations() {
+    let graph = GraphBuilder::new()
+        .add_node(oxidizedgraph::nodes::FunctionNode::new(
+            "step1",
+            |_state| async { Ok(NodeOutput::continue_to("step2")) },
+        ))
+        .add_node(oxidizedgraph::nodes::FunctionNode::new(
+            "step2",
+            |_state| async { Ok(NodeOutput::finish()) },
+        ))
+        .set_entry_point("step1")
+        .compile()
+        .unwrap();
+
+    let runner =
+        oxidizedgraph::runner::GraphRunner::new(graph, RunnerConfig::new().max_iterations(2));
+
+    let state = AgentState::new();
+    let result = runner.invoke(state).await;
+    assert!(
+        result.is_ok(),
+        "Failed with exact iterations limit for runner {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_streaming_runner_exact_iterations() {
+    let graph = GraphBuilder::new()
+        .add_node(oxidizedgraph::nodes::FunctionNode::new(
+            "step1",
+            |_state| async { Ok(NodeOutput::continue_to("step2")) },
+        ))
+        .add_node(oxidizedgraph::nodes::FunctionNode::new(
+            "step2",
+            |_state| async { Ok(NodeOutput::finish()) },
+        ))
+        .set_entry_point("step1")
+        .compile()
+        .unwrap();
+
+    let runner = oxidizedgraph::events::StreamingRunner::new(
+        graph,
+        std::sync::Arc::new(oxidizedgraph::events::EventBus::new()),
+    )
+    .with_config(RunnerConfig::new().max_iterations(2));
+
+    let state = AgentState::new();
+    let result = runner.invoke("test_thread_stream", state).await;
+    assert!(
+        result.is_ok(),
+        "Failed with exact iterations limit for streaming runner {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_checkpointing_runner_exact_iterations() {
+    let graph = GraphBuilder::new()
+        .add_node(oxidizedgraph::nodes::FunctionNode::new(
+            "step1",
+            |_state| async { Ok(NodeOutput::continue_to("step2")) },
+        ))
+        .add_node(oxidizedgraph::nodes::FunctionNode::new(
+            "step2",
+            |_state| async { Ok(NodeOutput::finish()) },
+        ))
+        .set_entry_point("step1")
+        .compile()
+        .unwrap();
+
+    let checkpointer = std::sync::Arc::new(oxidizedgraph::checkpoint::MemoryCheckpointer::new());
+    let runner = oxidizedgraph::checkpoint::CheckpointingRunner::new(graph, checkpointer)
+        .with_config(RunnerConfig::new().max_iterations(2));
+
+    let state = AgentState::new();
+    let result = runner.invoke("test_thread_checkpoint", state).await;
+    assert!(
+        result.is_ok(),
+        "Failed with exact iterations limit for checkpoint runner {:?}",
+        result
+    );
+}


### PR DESCRIPTION
Move the END node check to be before the max iterations check in the CheckpointingRunner and StreamingRunner. Previously, if max_iterations was hit on the same execution loop that the END node was encountered, it would erroneously return a RecursionLimit error instead of completing the graph.

---
*PR created automatically by Jules for task [12978509066009597569](https://jules.google.com/task/12978509066009597569) started by @stevei101*