### PR TITLE
test: PR-98 follow-up — tighten exact-iter assertions + add off-by-one boundary cases

### DIFF
--- a/tests/test_exact_iterations.rs
+++ b/tests/test_exact_iterations.rs
@@ -1,86 +1,232 @@
-use oxidizedgraph::prelude::*;
+//! Boundary tests around the END / iteration-limit check ordering fix
+//! (#98). The reordered branches in CheckpointingRunner and StreamingRunner
+//! moved END detection ahead of the iteration cap. These tests pin the
+//! happy path AND the symmetric edge cases — so a future regression that
+//! re-introduces an off-by-one (e.g. `iterations > max_iterations`,
+//! re-ordering the checks, or a tighter ASSERT) flips a red test instead
+//! of slipping through.
+//!
+//! Coverage matrix:
+//!
+//! | scenario                                        | expected     |
+//! |-------------------------------------------------|--------------|
+//! | 2-node graph, `max_iterations = 2` (exact)      | Completed    |
+//! | 2-node graph, `max_iterations = 1`              | RecursionLimit |
+//! | 1-node graph that immediately finishes,         |              |
+//! |   `max_iterations = 1` (exact)                  | Completed    |
+//! | 1-node graph that immediately finishes,         |              |
+//! |   `max_iterations = 0`                          | RecursionLimit |
+//!
+//! The "entry-point is literally `transitions::END`" case isn't
+//! constructible — `GraphBuilder::compile()` rejects an entry that
+//! isn't a registered node, so the runtime check that would handle it
+//! is dead-but-defensible. The boundary cases above cover every path
+//! that user code can actually reach.
+//! All three runners (`GraphRunner`, `StreamingRunner`, `CheckpointingRunner`)
+//! are exercised via the same shared graph builders so a future divergence
+//! in iteration accounting shows up in three tests, not one.
 
-#[tokio::test]
-async fn test_runner_exact_iterations() {
-    let graph = GraphBuilder::new()
+use oxidizedgraph::prelude::*;
+use std::sync::Arc;
+
+/// Build a two-step graph where `step2` writes a marker to the state.
+/// Used by the exact-iteration happy-path tests so we can assert the
+/// graph actually ran end-to-end, not just that the call returned `Ok`.
+fn two_step_graph_with_marker() -> oxidizedgraph::graph::CompiledGraph {
+    GraphBuilder::new()
         .add_node(oxidizedgraph::nodes::FunctionNode::new(
             "step1",
             |_state| async { Ok(NodeOutput::continue_to("step2")) },
         ))
         .add_node(oxidizedgraph::nodes::FunctionNode::new(
             "step2",
-            |_state| async { Ok(NodeOutput::finish()) },
+            |state| async move {
+                let mut guard = state.write().map_err(|e| {
+                    oxidizedgraph::error::NodeError::execution_failed(e.to_string())
+                })?;
+                guard.set_context("reached_step2", true);
+                Ok(NodeOutput::finish())
+            },
         ))
         .set_entry_point("step1")
         .compile()
-        .unwrap();
+        .expect("two-step graph compiles")
+}
 
-    let runner =
-        oxidizedgraph::runner::GraphRunner::new(graph, RunnerConfig::new().max_iterations(2));
+/// Single-step graph that immediately finishes on the entry node.
+/// Used by the off-by-one boundary tests.
+fn single_step_graph() -> oxidizedgraph::graph::CompiledGraph {
+    GraphBuilder::new()
+        .add_node(oxidizedgraph::nodes::FunctionNode::new(
+            "only",
+            |state| async move {
+                let mut guard = state.write().map_err(|e| {
+                    oxidizedgraph::error::NodeError::execution_failed(e.to_string())
+                })?;
+                guard.set_context("reached_only", true);
+                Ok(NodeOutput::finish())
+            },
+        ))
+        .set_entry_point("only")
+        .compile()
+        .expect("single-step graph compiles")
+}
 
-    let state = AgentState::new();
-    let result = runner.invoke(state).await;
-    assert!(
-        result.is_ok(),
-        "Failed with exact iterations limit for runner {:?}",
-        result
+// ───────────────────────────────────────────────────────────────────────
+// Happy path: exact-iteration limit completes — and the graph actually ran
+// ───────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn graph_runner_completes_on_exact_iteration_limit() {
+    let runner = oxidizedgraph::runner::GraphRunner::new(
+        two_step_graph_with_marker(),
+        RunnerConfig::new().max_iterations(2),
+    );
+    let final_state = runner
+        .invoke(AgentState::new())
+        .await
+        .expect("exact-iter run must complete");
+    assert_eq!(
+        final_state.get_context::<bool>("reached_step2"),
+        Some(true),
+        "step2 must have actually run, not just been counted"
     );
 }
 
 #[tokio::test]
-async fn test_streaming_runner_exact_iterations() {
-    let graph = GraphBuilder::new()
-        .add_node(oxidizedgraph::nodes::FunctionNode::new(
-            "step1",
-            |_state| async { Ok(NodeOutput::continue_to("step2")) },
-        ))
-        .add_node(oxidizedgraph::nodes::FunctionNode::new(
-            "step2",
-            |_state| async { Ok(NodeOutput::finish()) },
-        ))
-        .set_entry_point("step1")
-        .compile()
-        .unwrap();
-
+async fn streaming_runner_completes_on_exact_iteration_limit() {
     let runner = oxidizedgraph::events::StreamingRunner::new(
-        graph,
-        std::sync::Arc::new(oxidizedgraph::events::EventBus::new()),
+        two_step_graph_with_marker(),
+        Arc::new(oxidizedgraph::events::EventBus::new()),
     )
     .with_config(RunnerConfig::new().max_iterations(2));
 
-    let state = AgentState::new();
-    let result = runner.invoke("test_thread_stream", state).await;
+    let result = runner
+        .invoke("test_thread_stream", AgentState::new())
+        .await
+        .expect("exact-iter run must complete");
     assert!(
-        result.is_ok(),
-        "Failed with exact iterations limit for streaming runner {:?}",
-        result
+        matches!(
+            result,
+            oxidizedgraph::events::StreamingRunResult::Completed(_)
+        ),
+        "must be the Completed variant, not some other Ok branch: {result:?}"
+    );
+    let oxidizedgraph::events::StreamingRunResult::Completed(state) = result else {
+        unreachable!()
+    };
+    assert_eq!(state.get_context::<bool>("reached_step2"), Some(true));
+}
+
+#[tokio::test]
+async fn checkpointing_runner_completes_on_exact_iteration_limit() {
+    let checkpointer = Arc::new(oxidizedgraph::checkpoint::MemoryCheckpointer::new());
+    let runner = oxidizedgraph::checkpoint::CheckpointingRunner::new(
+        two_step_graph_with_marker(),
+        checkpointer,
+    )
+    .with_config(RunnerConfig::new().max_iterations(2));
+
+    let result = runner
+        .invoke("test_thread_checkpoint", AgentState::new())
+        .await
+        .expect("exact-iter run must complete");
+    assert!(
+        matches!(result, oxidizedgraph::checkpoint::RunResult::Completed(_)),
+        "must be Completed, not Interrupted/etc: {result:?}"
+    );
+    assert_eq!(
+        result.state().get_context::<bool>("reached_step2"),
+        Some(true)
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Boundary: iteration cap below required still rejects (verifies the
+// reorder didn't disable the iter check)
+// ───────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn graph_runner_rejects_when_max_is_below_required() {
+    // 2-node graph needs 2 transitions worth of work; max=1 must
+    // RecursionLimit. Without this, a future tweak that always-completes
+    // on END before checking iter would silently neuter the cap.
+    let runner = oxidizedgraph::runner::GraphRunner::new(
+        two_step_graph_with_marker(),
+        RunnerConfig::new().max_iterations(1),
+    );
+    let err = runner.invoke(AgentState::new()).await.unwrap_err();
+    assert!(
+        matches!(err, oxidizedgraph::error::RuntimeError::RecursionLimit(1)),
+        "expected RecursionLimit(1), got {err:?}"
     );
 }
 
 #[tokio::test]
-async fn test_checkpointing_runner_exact_iterations() {
-    let graph = GraphBuilder::new()
-        .add_node(oxidizedgraph::nodes::FunctionNode::new(
-            "step1",
-            |_state| async { Ok(NodeOutput::continue_to("step2")) },
-        ))
-        .add_node(oxidizedgraph::nodes::FunctionNode::new(
-            "step2",
-            |_state| async { Ok(NodeOutput::finish()) },
-        ))
-        .set_entry_point("step1")
-        .compile()
-        .unwrap();
-
-    let checkpointer = std::sync::Arc::new(oxidizedgraph::checkpoint::MemoryCheckpointer::new());
-    let runner = oxidizedgraph::checkpoint::CheckpointingRunner::new(graph, checkpointer)
-        .with_config(RunnerConfig::new().max_iterations(2));
-
-    let state = AgentState::new();
-    let result = runner.invoke("test_thread_checkpoint", state).await;
-    assert!(
-        result.is_ok(),
-        "Failed with exact iterations limit for checkpoint runner {:?}",
-        result
-    );
+async fn streaming_runner_rejects_when_max_is_below_required() {
+    let runner = oxidizedgraph::events::StreamingRunner::new(
+        two_step_graph_with_marker(),
+        Arc::new(oxidizedgraph::events::EventBus::new()),
+    )
+    .with_config(RunnerConfig::new().max_iterations(1));
+    let err = runner
+        .invoke("rejects", AgentState::new())
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        oxidizedgraph::error::RuntimeError::RecursionLimit(1)
+    ));
 }
+
+#[tokio::test]
+async fn checkpointing_runner_rejects_when_max_is_below_required() {
+    let checkpointer = Arc::new(oxidizedgraph::checkpoint::MemoryCheckpointer::new());
+    let runner = oxidizedgraph::checkpoint::CheckpointingRunner::new(
+        two_step_graph_with_marker(),
+        checkpointer,
+    )
+    .with_config(RunnerConfig::new().max_iterations(1));
+    let err = runner
+        .invoke("rejects", AgentState::new())
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        oxidizedgraph::error::RuntimeError::RecursionLimit(1)
+    ));
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Boundary: single-step graph with max=1 (exact) and max=0 (below)
+// ───────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn graph_runner_single_step_with_exact_max_completes() {
+    let runner = oxidizedgraph::runner::GraphRunner::new(
+        single_step_graph(),
+        RunnerConfig::new().max_iterations(1),
+    );
+    let final_state = runner.invoke(AgentState::new()).await.unwrap();
+    assert_eq!(final_state.get_context::<bool>("reached_only"), Some(true));
+}
+
+#[tokio::test]
+async fn graph_runner_single_step_with_zero_max_rejects() {
+    let runner = oxidizedgraph::runner::GraphRunner::new(
+        single_step_graph(),
+        RunnerConfig::new().max_iterations(0),
+    );
+    let err = runner.invoke(AgentState::new()).await.unwrap_err();
+    assert!(matches!(
+        err,
+        oxidizedgraph::error::RuntimeError::RecursionLimit(0)
+    ));
+}
+
+// Note: the "entry point is literally END" degenerate case named in the
+// PR-#98 review is not constructible via the public API — `GraphBuilder::compile`
+// validates that the entry node exists, and `transitions::END = "__end__"`
+// is not a registerable node id. The runtime semantics of "END check before
+// iter check" therefore only matter when execution REACHES END after at
+// least one step, which the cases above already cover at the boundary.


### PR DESCRIPTION
Follow-up to #98 (merged at \`1cae7ff\`). Addresses the four CRR findings on that PR.

## Changes

### 1. Tighter assertions
The three existing tests asserted only \`result.is_ok()\` — a future change that returned \`Ok(Suspended)\` or \`Ok(Cancelled)\` on the same control-flow path would slip through. Now each runner test:
- pattern-matches on the specific \`Completed(_)\` variant where applicable
- asserts the graph actually executed (via a \`reached_step2\` context marker step2 writes), not just that the call returned Ok

### 2. Symmetric edge cases — verifies the iteration cap still fires
Three new tests, one per runner, on the 2-node graph with \`max_iterations(1)\` — must surface \`RecursionLimit(1)\`. A future tweak that always-completes-on-END before checking iter would flip these red instead of slipping through.

### 3. Single-step boundary
Two new tests on a single-node graph that immediately finishes:
- \`max=1\` (exact) → completes, node ran
- \`max=0\` → \`RecursionLimit(0)\`

### 4. DRY setup
Extracted \`two_step_graph_with_marker()\` and \`single_step_graph()\` helpers. The previous three test bodies copied ~13 lines of \`GraphBuilder\` construction; now there's one canonical builder per shape, and the context marker the asserts read lives next to the node that writes it.

## What this PR does NOT do

- The "entry-point is literally \`transitions::END\`" edge case named in the review is documented as **not constructible** — \`GraphBuilder::compile()\` rejects an entry id that isn't a registered node, so the runtime END check at iteration 0 is defensible-but-unreachable from user code. The file's coverage matrix comment names this so the gap doesn't read as oversight.
- Altitude finding (final-state checkpoint on END completion for the CheckpointingRunner) is out of scope here; it changes behaviour, not test coverage.

## Verification

- \`cargo test --test test_exact_iterations\` — **8 passing**, 0 failed
- \`cargo clippy --tests -- -D warnings\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)