### PR TITLE
chore: point Nix substituter at nix-cache.lornu.ai

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -130,8 +130,8 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             accept-flake-config = true
-            extra-substituters = https://nix-cache.stevedores.org
-            extra-trusted-public-keys = nix-cache.stevedores.org-1:Y2WLZtQTgxQ2QQzUnRDkDDKX08dL3NoNZ+Ohw3jv+7I=
+            extra-substituters = https://nix-cache.lornu.ai
+            extra-trusted-public-keys = nix-cache.lornu.ai-1:Y2WLZtQTgxQ2QQzUnRDkDDKX08dL3NoNZ+Ohw3jv+7I=
       - name: build server-image
         run: nix build .#server-image -L --no-link
 
@@ -184,8 +184,8 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             accept-flake-config = true
-            extra-substituters = https://nix-cache.stevedores.org
-            extra-trusted-public-keys = nix-cache.stevedores.org-1:Y2WLZtQTgxQ2QQzUnRDkDDKX08dL3NoNZ+Ohw3jv+7I=
+            extra-substituters = https://nix-cache.lornu.ai
+            extra-trusted-public-keys = nix-cache.lornu.ai-1:Y2WLZtQTgxQ2QQzUnRDkDDKX08dL3NoNZ+Ohw3jv+7I=
 
       - name: Install skopeo
         run: sudo apt-get update -qq && sudo apt-get install -y -qq skopeo

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -19,19 +19,19 @@ IMAGE_TAG="$(git rev-parse --short HEAD)" just push
 
 `flake.nix` does **not** set `nixConfig.extra-substituters` (it only applies for trusted users or with `--accept-flake-config`, and otherwise warns on every `nix` invocation).
 
-To use `https://nix-cache.stevedores.org` locally, pick one:
+To use `https://nix-cache.lornu.ai` locally, pick one:
 
 ```bash
 # One-shot
 nix build .#server-image --accept-flake-config \
-  --extra-substituters https://nix-cache.stevedores.org \
-  --extra-trusted-public-keys 'nix-cache.stevedores.org-1:Y2WLZtQTgxQ2QQzUnRDkDDKX08dL3NoNZ+Ohw3jv+7I='
+  --extra-substituters https://nix-cache.lornu.ai \
+  --extra-trusted-public-keys 'nix-cache.lornu.ai-1:Y2WLZtQTgxQ2QQzUnRDkDDKX08dL3NoNZ+Ohw3jv+7I='
 
 # Persistent (user nix.conf)
 mkdir -p ~/.config/nix
 cat >> ~/.config/nix/nix.conf <<'EOF'
-extra-substituters = https://nix-cache.stevedores.org
-extra-trusted-public-keys = nix-cache.stevedores.org-1:Y2WLZtQTgxQ2QQzUnRDkDDKX08dL3NoNZ+Ohw3jv+7I=
+extra-substituters = https://nix-cache.lornu.ai
+extra-trusted-public-keys = nix-cache.lornu.ai-1:Y2WLZtQTgxQ2QQzUnRDkDDKX08dL3NoNZ+Ohw3jv+7I=
 EOF
 ```
 


### PR DESCRIPTION
## Summary
- Point all Nix substituters at `https://nix-cache.lornu.ai`
- Trust the `lornu-1` signing key instead of stevedores cache keys
- Remove transitional `nix-cache.stevedores.org` fallback where present

## Test plan
- [ ] `nix flake check` (or repo CI) resolves store paths from `nix-cache.lornu.ai`
- [ ] No references to `nix-cache.stevedores.org` remain in changed files

Made with [Cursor](https://cursor.com)